### PR TITLE
Set the bot's nick to that of the currently playing song

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ async def stop():
 
     # Restore the bot's original nick (if it exists)
     if original_bot_nickname and current_channel:
-        bot_member = current_channel.get_member(client.user.id)
+        bot_member = current_channel.guild.get_member(client.user.id)
         await bot_member.edit(nick=original_bot_nickname)
 
 

--- a/main.py
+++ b/main.py
@@ -183,8 +183,10 @@ def play_next_song(e=None):
         # This allows people to quickly see which song is currently playing.
         new_nick = f"{author.nick or author.name} - {filename}"
 
-        # Truncate name to 32 characters
-        new_nick = new_nick[:32]
+        # If necessary, truncate name to 32 characters (the maximum allowed by Discord),
+        # including an ellipsis on the end.
+        if len(new_nick) > 32:
+            new_nick = new_nick[:31] + "…"
 
         # Set the new nickname
         await bot_member.edit(nick=new_nick)

--- a/main.py
+++ b/main.py
@@ -77,10 +77,10 @@ async def on_message(message: Message):
             return
 
         await message.channel.send("Aight I'll shut up.")
-        stop()
+        await stop()
 
 
-def stop():
+async def stop():
     """Stop playing music."""
     # Clear the queue
     global current_channel_content
@@ -88,6 +88,11 @@ def stop():
 
     # Stop playing music
     active_voice_client.stop()
+
+    # Restore the bot's original nick (if it exists)
+    if original_bot_nickname and current_channel:
+        bot_member = current_channel.get_member(client.user.id)
+        await bot_member.edit(nick=original_bot_nickname)
 
 
 async def play(message: Message):


### PR DESCRIPTION
Partially addresses #3. This PR sets Busty's nick to that of the currently playing song. Her original nick is restored after playback has concluded. It looks like:

![image](https://user-images.githubusercontent.com/1342360/148304835-df35aae7-02b3-407f-802d-7b058f5c24ca.png)

Only partially addresses, as adding an emoji to the name will be done in a separate PR (I'm thinking of pulling the set of allowed emoji from a configurable text file).

Reviewable by commit, although there's only 2.