### PR TITLE
Add a missing return upon running out of songs to play

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,8 @@ def stop():
     global current_channel_content
     current_channel_content = None
 
-    # Stop playing music
+    # Stop playing music. Note that this will run play_next_song, when runs
+    # after each song stops playing.
     active_voice_client.stop()
 
 

--- a/main.py
+++ b/main.py
@@ -153,6 +153,8 @@ def play_next_song(e=None):
             current_channel = None
             current_channel_content = None
 
+            return
+
         # Wait some time between songs
         if seconds_between_songs:
             await current_channel.send(f"Chillin' for {seconds_between_songs} seconds...")


### PR DESCRIPTION
We should exit `play_next_song` early upon running out of songs. Otherwise we'll just go ahead and try to queue up the next song, as well as say "Chilling ..." when the show is over.