### PR TITLE
Add linting CI to the repo and a lint script for local checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ name: Lint
 
 on:
   push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, then lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U isort==5.10.1 flake8==4.0.1 flake8-comprehensions==3.7.0 black==21.12b0
+
+    - name: Check import statement sorting
+      run: |
+        isort -c --df main.py
+
+    - name: Python syntax errors, undefined names, etc.
+      run: |
+        flake8 main.py --count --show-source --statistics
+
+    - name: PEP8 formatting
+      run: |
+        black --check --diff main.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/main.py
+++ b/main.py
@@ -1,20 +1,20 @@
-import discord
 import asyncio
 import os
+from os import path
+from typing import List, Optional, Tuple
 
+import discord
 from discord import (
-    Message,
-    TextChannel,
-    Member,
-    VoiceClient,
-    ClientException,
     ChannelType,
+    ClientException,
     Forbidden,
     HTTPException,
+    Member,
+    Message,
     NotFound,
+    TextChannel,
+    VoiceClient,
 )
-from os import path
-from typing import List, Tuple, Optional
 
 ## SETTINGS
 # How many seconds to wait in-between songs

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ client = discord.Client(intents=intents)
 
 @client.event
 async def on_ready():
-    print('We have logged in as {0.user}.'.format(client))
+    print("We have logged in as {0.user}.".format(client))
 
 
 @client.event
@@ -110,7 +110,9 @@ async def play(message: Message):
     # Join active voice call
     voice_channels = message.guild.voice_channels + message.guild.stage_channels
     if not voice_channels:
-        await message.channel.send("You need to be in an active voice or stage channel, sugar.")
+        await message.channel.send(
+            "You need to be in an active voice or stage channel, sugar."
+        )
         return
 
     # Get a reference to the bot's Member object
@@ -174,7 +176,9 @@ def play_next_song(e=None):
                 await bot_member.edit(nick=original_bot_nickname)
 
             # Say our goodbyes
-            await current_channel.send("Thas it y'all. Hope ya had a good **BUST** ❤️‍🔥 ")
+            await current_channel.send(
+                "Thas it y'all. Hope ya had a good **BUST** ❤️‍🔥 "
+            )
 
             # Clear the current channel and content
             current_channel = None
@@ -184,13 +188,17 @@ def play_next_song(e=None):
 
         # Wait some time between songs
         if seconds_between_songs:
-            await current_channel.send(f"Chillin' for {seconds_between_songs} seconds...")
+            await current_channel.send(
+                f"Chillin' for {seconds_between_songs} seconds..."
+            )
             await asyncio.sleep(seconds_between_songs)
 
         # Pop a song off the front of the queue and play it
         author, filename, local_filepath = current_channel_content.pop(0)
         await current_channel.send(f"**Playing:** {author.mention} - `{filename}`.")
-        active_voice_client.play(discord.FFmpegPCMAudio(local_filepath), after=play_next_song)
+        active_voice_client.play(
+            discord.FFmpegPCMAudio(local_filepath), after=play_next_song
+        )
 
         # Change the name of the bot to that of the currently playing song.
         # This allows people to quickly see which song is currently playing.
@@ -213,7 +221,9 @@ async def list(message: Message):
 
     message_to_send = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥\n\n**Track Listing**"
 
-    for index, (author, filename, media_content_bytes) in enumerate(channel_media_attachments):
+    for index, (author, filename, media_content_bytes) in enumerate(
+        channel_media_attachments
+    ):
         message_to_send += f"""
 {index+1}. {author.mention} - `{filename}`"""
 
@@ -222,9 +232,11 @@ async def list(message: Message):
     try:
         await list_message.pin()
     except Forbidden:
-        print('Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again')
+        print(
+            'Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again'
+        )
     except (HTTPException, NotFound) as e:
-        print('Pinning tracklist failed: ', e)
+        print("Pinning tracklist failed: ", e)
 
     # Update global channel content
     global current_channel_content
@@ -249,25 +261,31 @@ async def scrape_channel_media(channel: TextChannel) -> List[Tuple[Member, str, 
             continue
 
         for attachment in message.attachments:
-            if (
-                not attachment.content_type.startswith("audio")
-                and not attachment.content_type.startswith("video")
-            ):
+            if not attachment.content_type.startswith(
+                "audio"
+            ) and not attachment.content_type.startswith("video"):
                 # Ignore non-audio/video attachments
                 continue
 
             # Save attachment content
             # TODO: Parse mp3 tags and things
-            attachment_filepath = path.join(attachment_directory_filepath, attachment.filename)
+            attachment_filepath = path.join(
+                attachment_directory_filepath, attachment.filename
+            )
             await attachment.save(attachment_filepath)
 
-            channel_media_attachments.append((message.author, attachment.filename, attachment_filepath))
+            channel_media_attachments.append(
+                (message.author, attachment.filename, attachment_filepath)
+            )
 
     return channel_media_attachments
+
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with
 # a valid Discord bot access token.
 if "BUSTY_DISCORD_TOKEN" in os.environ:
     client.run(os.environ["BUSTY_DISCORD_TOKEN"])
 else:
-    print("Please pass in a Discord bot token via the BUSTY_DISCORD_TOKEN environment variable")
+    print(
+        "Please pass in a Discord bot token via the BUSTY_DISCORD_TOKEN environment variable"
+    )

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from discord import (
     VoiceClient,
 )
 
-## SETTINGS
+# SETTINGS
 # How many seconds to wait in-between songs
 seconds_between_songs = int(os.environ.get("BUSTY_COOLDOWN_SECS", 10))
 # Where to save media files locally
@@ -24,7 +24,7 @@ attachment_directory_filepath = os.environ.get("BUSTY_ATTACHMENT_DIR", "attachme
 # The Discord role needed to perform bot commands
 dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
 
-## GLOBAL VARIABLES
+# GLOBAL VARIABLES
 # The channel to send messages in
 current_channel: Optional = None
 # The media in the current channel
@@ -35,7 +35,7 @@ active_voice_client: Optional[VoiceClient] = None
 # changed while songs are being played.
 original_bot_nickname: Optional[str] = None
 
-## STARTUP
+# STARTUP
 # This is necessary to query server members
 intents = discord.Intents.default()
 intents.members = True
@@ -223,7 +223,7 @@ async def list(message: Message):
         await list_message.pin()
     except Forbidden:
         print('Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again')
-    except (HTTPException, NotFound)  as e:
+    except (HTTPException, NotFound) as e:
         print('Pinning tracklist failed: ', e)
 
     # Update global channel content

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Runs linting scripts over the local checkout. Can be run as:
+# ./lint.sh
+# to lint all project files, or as:
+# ./lint.sh file.py directory file2.py
+# to lint specific files and directories.
+#
+# List of commands that are run:
+# isort - sorts import statements
+# flake8 - lints and finds mistakes
+# black - opinionated code formatter
+
+set -e
+
+if [ $# -ge 1 ]
+then
+    files=$*
+  else
+    files="main.py"
+fi
+
+echo "Linting these locations: $files"
+isort $files
+flake8 $files
+python3 -m black $files

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[flake8]
+# see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# for error codes. The ones we ignore are:
+#   W503: line break before binary operator
+#   W504: line break after binary operator
+#   E203: whitespace before ':'
+#   E731: do not assign a lambda expression, use a def
+#   E501: Line too long (black enforces this for us)
+ignore=W503,W504,E203,E731,E501
+
+[isort]
+line_length = 88
+sections=FUTURE,STDLIB,THIRDPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+multi_line_output=3
+include_trailing_comma=true
+combine_as_imports=true


### PR DESCRIPTION
This PR adds linting for continuous integration to the repo, defined by the [.github/workflows/lint.yml](https://github.com/anoadragon453/busty/blob/anoa/lint_ci/.github/workflows/lint.yml) file. It also adds a bash script at [scripts-dev/lint.sh](https://github.com/anoadragon453/busty/blob/anoa/lint_ci/scripts-dev/lint.sh), which is useful for linting your code just before you commit. This also ensures that CI will pass before creating a PR.

The linting tools that are run are:

- [isort](https://pypi.org/project/isort/) - sorts import statements
- [flake8](https://pypi.org/project/flake8/) - lints and finds mistakes
- [black](https://pypi.org/project/black/) - opinionated code formatter

I'm open to opinions on including others! Settings for each are defined in `setup.cfg`.

Note that these need to be installed prior to running `lint.sh`. The versions of each are defined in the CI workflow, and it is the essential to install the same versions locally in order to ensure that the results when running `lint.sh` locally agree with CI.

~~Based on https://github.com/anoadragon453/busty/pull/14 as it will conflict with that PR. Unfortunately, it will also conflict with other PRs. I think we should push to merge this one ASAP after #14 though, to avoid further conflicts. This PR will be rebased after #14 merges.~~ This PR has been rebased.

Best reviewed commit-by-commit.