### PR TITLE
Fix master -> main default branch name in CI config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
I pulled the CI config from an older repo of mine which had `master` as the default branch name, rather than `main` which we use here (and is now default across new GitHub repositories).