### PR TITLE
Revamp "Now Playing" and "Chillin" messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -297,7 +297,7 @@ async def command_list(message: Message):
 async def scrape_channel_media(
     channel: TextChannel,
 ) -> List[Tuple[Message, Attachment, str]]:
-    # A list of (uploader, filename, local filepath, message jump url)
+    # A list of (original message, message attachment, local filepath)
     channel_media_attachments: List[Tuple[Message, Attachment, str]] = []
 
     # Ensure attachment directory exists


### PR DESCRIPTION
Resolves Issue #2.

Make the "Now Playing" and waiting messages rich text embed for better visibility. Also add a number of other features like

- Direct file jumping (like in !list)
- Direct message jumping (like in !list)
- Re-posting text sent with original submission
![image](https://user-images.githubusercontent.com/6956898/149632542-af9d755e-27d9-4adb-ba05-ca9157a8bcbd.png)

Also includes a slight internal restructure. The return tuple of the `scrape_channel_media` function was getting bloated, so it now keeps direct references to the original message and attachment from which most previously included fields can be derived.