### PR TITLE
Format filenames more nicely

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,6 +97,17 @@ async def on_message(message: Message):
         await command_stop()
 
 
+# Take a filename as string and return it formatted nicely
+def format_filename(filename):
+    # Remove file extension
+    filename = path.splitext(filename)[0]
+
+    # Replace all underscores with spaces
+    filename = filename.replace("_", " ")
+
+    return discord.utils.escape_markdown(filename)
+
+
 async def command_stop():
     """Stop playing music."""
     # Clear the queue
@@ -219,7 +230,7 @@ def play_next_song(e=None):
         list_format = "{0} - [{1}]({2}) [`↲jump`]({3})"
         embed_content = list_format.format(
             submit_message.author.mention,
-            discord.utils.escape_markdown(attachment.filename),
+            format_filename(attachment.filename),
             attachment.url,
             submit_message.jump_url,
         )
@@ -268,7 +279,7 @@ async def command_list(message: Message):
         embed_content += list_format.format(
             index + 1,
             submit_message.author.mention,
-            discord.utils.escape_markdown(attachment.filename),
+            format_filename(attachment.filename),
             attachment.url,
             submit_message.jump_url,
         )

--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ async def on_message(message: Message):
 
 
 # Take a filename as string and return it formatted nicely
-def format_filename(filename):
+def format_filename(filename: str):
     # Remove file extension
     filename = path.splitext(filename)[0]
 


### PR DESCRIPTION
Currently we print song titles as the names of the files attached. To make them look nicer, we can

- Drop the file extension
- Replace underscores with spaces

I've attached an image where I did some experimentation and concluded that Discord does not allow filenames starting with underscores, so we should not get any "empty" song names this way. Currently multiple spaces seem to be consolidated to one space. I'm fairly sure this is an issue with the way Discord renders the embed and not anything in this code, but there might be a way to fix it.

I think needing to maintain the exact number of underscores as they convert to spaces is such an obscure use case we can ignore it for now (or forever).

![image](https://user-images.githubusercontent.com/6956898/149635600-45d9ae08-4c92-4332-a66a-14c3b8b6cf20.png)
