### PR TITLE
Allow !list with target channel

### DIFF
--- a/main.py
+++ b/main.py
@@ -284,6 +284,13 @@ async def command_list(message: Message):
     # if any channels were mentioned in the message, use the first from the list
     if message.channel_mentions:
         target_channel = message.channel_mentions[0]
+    if message.channel_mentions:
+        mentioned_channel = message.channel_mentions[0]
+        if isinstance(mentioned_channel, TextChannel):
+            target_channel = mentioned_channel
+        else:
+            await message.channel.send("That ain't a text channel.")
+            return
 
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await scrape_channel_media(target_channel)
@@ -309,7 +316,7 @@ async def command_list(message: Message):
     embed = discord.Embed(title=embed_title, description=embed_content, color=0xDD2E44)
     list_message = await message.channel.send(embed=embed)
 
-    # Only pin message if command is called from the target channel
+    # Only pin the message if the command is called from the target channel
     if target_channel == message.channel:
         try:
             await list_message.pin()

--- a/main.py
+++ b/main.py
@@ -280,8 +280,13 @@ def play_next_song(e=None):
 
 
 async def command_list(message: Message):
-    # Scrape all tracks in the message's channel and list them
-    channel_media_attachments = await scrape_channel_media(message.channel)
+    target_channel = message.channel
+    # if any channels were mentioned in the message, use the first from the list
+    if message.channel_mentions:
+        target_channel = message.channel_mentions[0]
+
+    # Scrape all tracks in the target channel and list them
+    channel_media_attachments = await scrape_channel_media(target_channel)
 
     embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
     embed_content = "**Track Listing**\n"
@@ -300,25 +305,27 @@ async def command_list(message: Message):
             submit_message.jump_url,
         )
 
-    # Send the message and pin it
+    # Send the list message
     embed = discord.Embed(title=embed_title, description=embed_content, color=0xDD2E44)
     list_message = await message.channel.send(embed=embed)
 
-    try:
-        await list_message.pin()
-    except Forbidden:
-        print(
-            'Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again'
-        )
-    except (HTTPException, NotFound) as e:
-        print("Pinning tracklist failed: ", e)
+    # Only pin message if command is called from the target channel
+    if target_channel == message.channel:
+        try:
+            await list_message.pin()
+        except Forbidden:
+            print(
+                'Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again'
+            )
+        except (HTTPException, NotFound) as e:
+            print("Pinning tracklist failed: ", e)
 
     # Update global channel content
     global current_channel_content
     current_channel_content = channel_media_attachments
 
     global current_channel
-    current_channel = message.channel
+    current_channel = target_channel
 
 
 async def scrape_channel_media(


### PR DESCRIPTION
Closes #37.

Allows calling `!list <channel mention>`. This what the output message would be if you called `!list` in the mentioned channel, but sends the message in the same channel that the command was called from. The output of `!list` is now only pinned if the channel the command was called from is the same as the channel being listed.