### PR TITLE
Split !list to avoid 4096 embed char limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -299,6 +299,12 @@ async def command_list(message: Message):
 
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await scrape_channel_media(target_channel)
+
+    # Break on no songs to list
+    if len(embed_description_list) == 0:
+        await message.channel.send("There aint any songs there.")
+        return
+
     # Title of !list embed
     embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
     embed_description_prefix = "**Track Listing**\n"
@@ -339,15 +345,11 @@ async def command_list(message: Message):
         else:
             embed_description_current += song_list_entry
 
-    # Add the leftover part to a new embed (it it exists)
-    if len(embed_description_current) > 0:
-        embed_description_list.append(embed_description_current)
+    # Add the leftover part to a new embed
+    embed_description_list.append(embed_description_current)
 
     # Iterate through each embed description, send and list messages
     message_list = []
-    if len(embed_description_list) == 0:
-        await message.channel.send("There aint any songs there.")
-        return
 
     # Send messages, only first message gets title and prefix
     for index, embed_description in enumerate(embed_description_list):
@@ -374,8 +376,10 @@ async def command_list(message: Message):
                 print(
                     'Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again'
                 )
+                break
             except (HTTPException, NotFound) as e:
                 print("Pinning tracklist failed: ", e)
+                break
 
     # Update global channel content
     global current_channel_content

--- a/main.py
+++ b/main.py
@@ -313,7 +313,7 @@ async def command_list(message: Message):
         local_filepath,
     ) in enumerate(channel_media_attachments):
         list_format = "**{0}.** {1}: [{2}]({3}) [`↲jump`]({4})\n"
-        list_entry = list_format.format(
+        song_list_entry = list_format.format(
             index + 1,
             submit_message.author.mention,
             format_filename(attachment.filename),
@@ -329,15 +329,15 @@ async def command_list(message: Message):
         if (
             description_prefix_charcount
             + len(embed_description_current)
-            + len(list_entry)
+            + len(song_list_entry)
             > EMBED_DESCRIPTION_LIMIT
         ):
             # If adding a new list entry would go over, push our current list entries to an embed
             embed_description_stack.append(embed_description_current)
             # Start a new embed
-            embed_description_current = list_entry
+            embed_description_current = song_list_entry
         else:
-            embed_description_current += list_entry
+            embed_description_current += song_list_entry
 
     # Add the leftover part to a new embed (it it exists)
     if len(embed_description_current) > 0:

--- a/main.py
+++ b/main.py
@@ -284,10 +284,9 @@ def play_next_song(e=None):
 
 
 async def command_list(message: Message):
-    target_channel = message.channel
+    target_channel = None
+
     # if any channels were mentioned in the message, use the first from the list
-    if message.channel_mentions:
-        target_channel = message.channel_mentions[0]
     if message.channel_mentions:
         mentioned_channel = message.channel_mentions[0]
         if isinstance(mentioned_channel, TextChannel):
@@ -295,6 +294,8 @@ async def command_list(message: Message):
         else:
             await message.channel.send("That ain't a text channel.")
             return
+    else:
+        target_channel = message.channel
 
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await scrape_channel_media(target_channel)
@@ -362,16 +363,6 @@ async def command_list(message: Message):
                 )
             except (HTTPException, NotFound) as e:
                 print("Pinning tracklist failed: ", e)
-    # pin sent messages in reverse order
-    for list_message in reversed(message_stack):
-        try:
-            await list_message.pin()
-        except Forbidden:
-            print(
-                'Insufficient permission to pin tracklist. Please give me the "manage_messages" permission and try again'
-            )
-        except (HTTPException, NotFound) as e:
-            print("Pinning tracklist failed: ", e)
 
     # Update global channel content
     global current_channel_content

--- a/main.py
+++ b/main.py
@@ -320,8 +320,14 @@ async def command_list(message: Message):
             attachment.url,
             submit_message.jump_url,
         )
+
+        # We only add the embed description prefix to the first message
+        description_prefix_charcount = 0
+        if len(embed_description_stack) == 0:
+            description_prefix_charcount = len(embed_description_prefix)
+
         if (
-            len(embed_description_prefix)
+            description_prefix_charcount
             + len(embed_description_current)
             + len(list_entry)
             > EMBED_DESCRIPTION_LIMIT
@@ -343,12 +349,19 @@ async def command_list(message: Message):
         await message.channel.send("There aint any songs there.")
         return
 
-    for embed_description in embed_description_stack:
-        embed = discord.Embed(
-            title=embed_title,
-            description=embed_description_prefix + embed_description,
-            color=LIST_EMBED_COLOR,
-        )
+    # Send messages, only first message gets title and prefix
+    for index, embed_description in enumerate(embed_description_stack):
+        if index == 0:
+            embed = discord.Embed(
+                title=embed_title,
+                description=embed_description_prefix + embed_description,
+                color=LIST_EMBED_COLOR,
+            )
+        else:
+            embed = discord.Embed(
+                description=embed_description,
+                color=LIST_EMBED_COLOR,
+            )
         list_message = await message.channel.send(embed=embed)
         message_stack.append(list_message)
 

--- a/main.py
+++ b/main.py
@@ -19,10 +19,13 @@ from discord import (
 from tinytag import TinyTag
 
 # CONSTANTS
-# Max number of characters in an embed description (currently 4096 in Discord)
+# Max number of characters in an embed description
+# See https://discord.com/developers/docs/resources/channel#embed-limits
 EMBED_DESCRIPTION_LIMIT = 4096
 # Color of !list embed
 LIST_EMBED_COLOR = 0xDD2E44
+# Color of "Now Playing" embed
+PLAY_EMBED_COLOR = 0x33B86B
 
 # SETTINGS
 # How many seconds to wait in-between songs
@@ -216,7 +219,7 @@ def play_next_song(e=None):
             embed_title = "❤️‍🔥 Thas it y'all ❤️‍🔥"
             embed_content = "Hope ya had a good **BUST!**"
             embed = discord.Embed(
-                title=embed_title, description=embed_content, color=0xDD2E44
+                title=embed_title, description=embed_content, color=LIST_EMBED_COLOR
             )
             await current_channel.send(embed=embed)
 
@@ -257,7 +260,7 @@ def play_next_song(e=None):
             submit_message.jump_url,
         )
         embed = discord.Embed(
-            title=embed_title, description=embed_content, color=0x33B86B
+            title=embed_title, description=embed_content, color=PLAY_EMBED_COLOR
         )
         if submit_message.content:
             embed.add_field(
@@ -309,7 +312,7 @@ async def command_list(message: Message):
     embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
     embed_description_prefix = "**Track Listing**\n"
 
-    # List of embed descriptions to circumvent the 4096 character embed limit
+    # List of embed descriptions to circumvent the Discord character embed limit
     embed_description_list = []
     embed_description_current = ""
 
@@ -348,7 +351,7 @@ async def command_list(message: Message):
     # Add the leftover part to a new embed
     embed_description_list.append(embed_description_current)
 
-    # Iterate through each embed description, send and list messages
+    # Iterate through each embed description, send and pin messages
     message_list = []
 
     # Send messages, only first message gets title and prefix

--- a/main.py
+++ b/main.py
@@ -284,7 +284,7 @@ def play_next_song(e=None):
 
 
 async def command_list(message: Message):
-    target_channel = None
+    target_channel = message.channel
 
     # if any channels were mentioned in the message, use the first from the list
     if message.channel_mentions:
@@ -294,8 +294,6 @@ async def command_list(message: Message):
         else:
             await message.channel.send("That ain't a text channel.")
             return
-    else:
-        target_channel = message.channel
 
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await scrape_channel_media(target_channel)

--- a/main.py
+++ b/main.py
@@ -288,7 +288,7 @@ def play_next_song(e=None):
 async def command_list(message: Message):
     target_channel = message.channel
 
-    # if any channels were mentioned in the message, use the first from the list
+    # If any channels were mentioned in the message, use the first from the list
     if message.channel_mentions:
         mentioned_channel = message.channel_mentions[0]
         if isinstance(mentioned_channel, TextChannel):
@@ -299,11 +299,11 @@ async def command_list(message: Message):
 
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await scrape_channel_media(target_channel)
-    # title of !list embed
+    # Title of !list embed
     embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
     embed_description_prefix = "**Track Listing**\n"
 
-    # stack of embed descriptions to circumvent the 4096 character embed limit
+    # Stack of embed descriptions to circumvent the 4096 character embed limit
     embed_description_stack = []
     embed_description_current = ""
 
@@ -332,18 +332,18 @@ async def command_list(message: Message):
             + len(list_entry)
             > EMBED_DESCRIPTION_LIMIT
         ):
-            # if adding a new list entry would go over, push our current list entries to an embed
+            # If adding a new list entry would go over, push our current list entries to an embed
             embed_description_stack.append(embed_description_current)
-            # start a new embed
+            # Start a new embed
             embed_description_current = list_entry
         else:
             embed_description_current += list_entry
 
-    # add the leftover part to a new embed (it it exists)
+    # Add the leftover part to a new embed (it it exists)
     if len(embed_description_current) > 0:
         embed_description_stack.append(embed_description_current)
 
-    # iterate through each embed description, send and stack messages
+    # Iterate through each embed description, send and stack messages
     message_stack = []
     if len(embed_description_stack) == 0:
         await message.channel.send("There aint any songs there.")

--- a/main.py
+++ b/main.py
@@ -18,6 +18,12 @@ from discord import (
 )
 from tinytag import TinyTag
 
+# CONSTANTS
+# Max number of characters in an embed description (currently 4096 in Discord)
+EMBED_DESCRIPTION_LIMIT = 4096
+# Color of !list embed
+LIST_EMBED_COLOR = 0xDD2E44
+
 # SETTINGS
 # How many seconds to wait in-between songs
 seconds_between_songs = int(os.environ.get("BUSTY_COOLDOWN_SECS", 10))
@@ -25,10 +31,6 @@ seconds_between_songs = int(os.environ.get("BUSTY_COOLDOWN_SECS", 10))
 attachment_directory_filepath = os.environ.get("BUSTY_ATTACHMENT_DIR", "attachments")
 # The Discord role needed to perform bot commands
 dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
-# Max number of characters in an embed description (currently 4096 in Discord)
-embed_description_limit = 4096
-# Color of !list embed
-list_embed_color = 0xDD2E44
 
 # GLOBAL VARIABLES
 # The channel to send messages in
@@ -322,7 +324,7 @@ async def command_list(message: Message):
             len(embed_description_prefix)
             + len(embed_description_current)
             + len(list_entry)
-            > embed_description_limit
+            > EMBED_DESCRIPTION_LIMIT
         ):
             # if adding a new list entry would go over, push our current list entries to an embed
             embed_description_stack.append(embed_description_current)
@@ -345,7 +347,7 @@ async def command_list(message: Message):
         embed = discord.Embed(
             title=embed_title,
             description=embed_description_prefix + embed_description,
-            color=list_embed_color,
+            color=LIST_EMBED_COLOR,
         )
         list_message = await message.channel.send(embed=embed)
         message_stack.append(list_message)

--- a/main.py
+++ b/main.py
@@ -303,8 +303,8 @@ async def command_list(message: Message):
     embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
     embed_description_prefix = "**Track Listing**\n"
 
-    # Stack of embed descriptions to circumvent the 4096 character embed limit
-    embed_description_stack = []
+    # List of embed descriptions to circumvent the 4096 character embed limit
+    embed_description_list = []
     embed_description_current = ""
 
     for index, (
@@ -323,7 +323,7 @@ async def command_list(message: Message):
 
         # We only add the embed description prefix to the first message
         description_prefix_charcount = 0
-        if len(embed_description_stack) == 0:
+        if len(embed_description_list) == 0:
             description_prefix_charcount = len(embed_description_prefix)
 
         if (
@@ -332,8 +332,8 @@ async def command_list(message: Message):
             + len(song_list_entry)
             > EMBED_DESCRIPTION_LIMIT
         ):
-            # If adding a new list entry would go over, push our current list entries to an embed
-            embed_description_stack.append(embed_description_current)
+            # If adding a new list entry would go over, push our current list entries to a new embed
+            embed_description_list.append(embed_description_current)
             # Start a new embed
             embed_description_current = song_list_entry
         else:
@@ -341,16 +341,16 @@ async def command_list(message: Message):
 
     # Add the leftover part to a new embed (it it exists)
     if len(embed_description_current) > 0:
-        embed_description_stack.append(embed_description_current)
+        embed_description_list.append(embed_description_current)
 
-    # Iterate through each embed description, send and stack messages
-    message_stack = []
-    if len(embed_description_stack) == 0:
+    # Iterate through each embed description, send and list messages
+    message_list = []
+    if len(embed_description_list) == 0:
         await message.channel.send("There aint any songs there.")
         return
 
     # Send messages, only first message gets title and prefix
-    for index, embed_description in enumerate(embed_description_stack):
+    for index, embed_description in enumerate(embed_description_list):
         if index == 0:
             embed = discord.Embed(
                 title=embed_title,
@@ -363,11 +363,11 @@ async def command_list(message: Message):
                 color=LIST_EMBED_COLOR,
             )
         list_message = await message.channel.send(embed=embed)
-        message_stack.append(list_message)
+        message_list.append(list_message)
 
     # If message channel == target channel, pin messages in reverse order
     if target_channel == message.channel:
-        for list_message in reversed(message_stack):
+        for list_message in reversed(message_list):
             try:
                 await list_message.pin()
             except Forbidden:

--- a/main.py
+++ b/main.py
@@ -301,7 +301,7 @@ async def command_list(message: Message):
     channel_media_attachments = await scrape_channel_media(target_channel)
 
     # Break on no songs to list
-    if len(embed_description_list) == 0:
+    if len(channel_media_attachments) == 0:
         await message.channel.send("There aint any songs there.")
         return
 


### PR DESCRIPTION
Discord embed descriptions have a 4096 character limit ([source](https://discord.com/developers/docs/resources/channel#embed-limits)). The `!list` command can exceed this limit, so to circumvent this we split into consecutive embeds, then pin them in reverse order so they appear in the proper order in the channel pins.