### PR TITLE
Prevent an exception when using `!skip` or `!stop` outside of a bust

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ async def on_message(message: Message):
         await command_play(message)
 
     elif message.content.startswith("!skip"):
-        if not active_voice_client.is_playing():
+        if not active_voice_client or not active_voice_client.is_playing():
             await message.channel.send("Nothin' is playin'.")
             return
 
@@ -90,7 +90,7 @@ async def on_message(message: Message):
         command_skip()
 
     elif message.content.startswith("!stop"):
-        if not active_voice_client.is_playing():
+        if not active_voice_client or not active_voice_client.is_playing():
             await message.channel.send("Nothin' is playin'.")
             return
 


### PR DESCRIPTION
When the bot is not currently connected to a voice channel or stage, `active_voice_channel` will be `None`. Thus, using `active_voice_client.is_playing()` will fail.

This PR adds an additional check to ensure `active_voice_channel` is non-None before checking `is_playing()`.