### PR TITLE
Prevent executing !list while busting

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,10 @@ async def on_message(message: Message):
         return
 
     if message.content.startswith("!list"):
+        if active_voice_client and active_voice_client.is_connected():
+            await message.channel.send("We're busy bustin', sugar.")
+            return
+
         await command_list(message)
 
     elif message.content.startswith("!bust"):

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ async def on_message(message: Message):
         await command_play(message)
 
     elif message.content.startswith("!skip"):
-        if not active_voice_client.is_playing():
+        if not active_voice_client or not active_voice_client.is_playing():
             await message.channel.send("Nothin' is playin'.")
             return
 
@@ -90,7 +90,7 @@ async def on_message(message: Message):
         command_skip()
 
     elif message.content.startswith("!stop"):
-        if not active_voice_client.is_playing():
+        if not active_voice_client or not active_voice_client.is_playing():
             await message.channel.send("Nothin' is playin'.")
             return
 


### PR DESCRIPTION
Fixes #34 

If the playlist is already being consumed, `!list` is disabled. This is done by checking if the bot is in a voice channel.