### PR TITLE
Add missing type annotation for 'current_channel'

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
 
 # GLOBAL VARIABLES
 # The channel to send messages in
-current_channel: Optional = None
+current_channel: Optional[TextChannel] = None
 # The media in the current channel
 current_channel_content: Optional[List] = None
 # The actively connected voice client


### PR DESCRIPTION
Looks like I missed this in the initial implementation.

`current_channel` is the text channel that we intend to send messages/embeds in.