### PR TITLE
Save files with unique filenames

### DIFF
--- a/main.py
+++ b/main.py
@@ -446,7 +446,10 @@ async def scrape_channel_media(
 
             # Save attachment content
             attachment_filepath = path.join(
-                attachment_directory_filepath, attachment.filename
+                attachment_directory_filepath,
+                "{:03d}.{}".format(
+                    len(channel_media_attachments) + 1, attachment.filename
+                ),
             )
             await attachment.save(attachment_filepath)
 


### PR DESCRIPTION
Closes #31.

Instead of saving files with the filename direct from Discord, use the name `(Track #).(Discord Filename)` where the track number is formatted to be exactly 3 digits. Recall that busty only reads the first 500 messages, so 3 digits is sufficient. For ex the 7th song `my_song.mp3` would be saved as `007.my_song.mp3`. 
