### PR TITLE
Read cover art from audio files

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,8 +17,7 @@ from discord import (
     TextChannel,
     VoiceClient,
 )
-from PIL import Image
-from PIL import UnidentifiedImageError
+from PIL import Image, UnidentifiedImageError
 from tinytag import TinyTag
 
 # CONSTANTS
@@ -169,11 +168,11 @@ def get_cover_art(filename: str) -> Optional[discord.File]:
 
     # Get a file pointer to the bytes
     image_bytes_fp = BytesIO(image_data)
-    
+
     # Read the filetype of the bytes and discern the appropriate file extension
     try:
         image = Image.open(image_bytes_fp)
-    except UnidentifiedImageError as e:
+    except UnidentifiedImageError:
         print(f"Warning: Skipping unidentifiable cover art field in {filename}")
         return None
     image_file_extension = image.format

--- a/main.py
+++ b/main.py
@@ -161,7 +161,7 @@ def get_cover_art(filename: str) -> Optional[discord.File]:
     # get image data as bytes, make sure it doesn't go over 8MB
     # This is a safe lower bound on the Discord upload limit of 8MiB
     image_data = tags.get_image()
-    if image_data is None or len(image_data) > 8000000:
+    if image_data is None or len(image_data) > 8_000_000:
         return None
     image = Image.open(BytesIO(image_data))
     cover_filename = f"cover.{image.format}".lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pynacl>=1.4.0
 discord.py>=1.7.3
 tinytag==1.7.0
+pillow>=9.0


### PR DESCRIPTION
Closes #48.
![image](https://user-images.githubusercontent.com/6956898/150905236-7b2d1d03-c543-4a89-b67c-3cd548f2e787.png)


Rather than allowing users to send as large a file as they'd like, cover art filesize is capped to 8MB, or 8 million bytes. This is less than the actual Discord cap of (about) 8MiB, though the Discord cap CAN rise if the bot is in a boosted server.

Since the time take to upload the cover image does cause message latency, and since there's really no reason anyone needs cover art over 1MB let alone 8, I think this is a good cap (I'd even be ok lowering it).

This commit adds a dependency to Pillow, solely because we need to know which file format the cover art is, and it seems neither Discord nor TinyTag can detect this themselves. We are using such a small part of the Pillow library that it shouldn't be too difficult to eliminate this dependency by checking some magic bytes ourselves, but I propose that we accept the dependency for now and remove it later if we feel like it.