### PR TITLE
Truncate long messages in "More Info"

### DIFF
--- a/main.py
+++ b/main.py
@@ -326,11 +326,10 @@ def play_next_song(e=None):
 
         # Add message content as "More Info", truncating to the embed field.value character limit
         if submit_message.content:
-            embed.add_field(
-                name="More Info",
-                value=submit_message.content[:EMBED_FIELD_VALUE_LIMIT],
-                inline=False,
-            )
+            more_info = submit_message.content
+            if len(more_info) > EMBED_FIELD_VALUE_LIMIT:
+                more_info = more_info[: EMBED_FIELD_VALUE_LIMIT - 1] + "…"
+            embed.add_field(name="More Info", value=more_info, inline=False)
 
         cover_art = get_cover_art(local_filepath)
         if cover_art is not None:

--- a/main.py
+++ b/main.py
@@ -21,9 +21,11 @@ from PIL import Image, UnidentifiedImageError
 from tinytag import TinyTag
 
 # CONSTANTS
+# See https://discord.com/developers/docs/resources/channel#embed-limits for LIMIT values
 # Max number of characters in an embed description
-# See https://discord.com/developers/docs/resources/channel#embed-limits
 EMBED_DESCRIPTION_LIMIT = 4096
+# Max number of characters in an embed field.value
+EMBED_FIELD_VALUE_LIMIT = 1024
 # Color of !list embed
 LIST_EMBED_COLOR = 0xDD2E44
 # Color of "Now Playing" embed
@@ -322,9 +324,12 @@ def play_next_song(e=None):
             title=embed_title, description=embed_content, color=PLAY_EMBED_COLOR
         )
 
+        # Add message content as "More Info", truncating to the embed field.value character limit
         if submit_message.content:
             embed.add_field(
-                name="More Info", value=submit_message.content, inline=False
+                name="More Info",
+                value=submit_message.content[:EMBED_FIELD_VALUE_LIMIT],
+                inline=False,
             )
 
         cover_art = get_cover_art(local_filepath)


### PR DESCRIPTION
Fixes #54.
![image](https://user-images.githubusercontent.com/6956898/151073983-035a20ef-6573-43be-b20d-4f0512e9bcb6.png)

Messages over 1024 characters are truncated in "More Info" to 1023 chars plus the `…` character.