### PR TITLE
Remove attachments from disk on end of bust

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,9 +43,9 @@ dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
 # The channel to send messages in
 current_channel: Optional[TextChannel] = None
 # The media in the current channel
-current_channel_content: Optional[List] = None
+current_channel_content: Optional[List[Tuple[Message, Attachment, str]]] = None
 # The local filepaths of media from the current bust
-current_bust_content: Optional[List] = None
+current_bust_content: Optional[List[str]] = None
 # The actively connected voice client
 active_voice_client: Optional[VoiceClient] = None
 # The nickname of the bot. We need to store it as it will be


### PR DESCRIPTION
Implements #52 
A copy of list of attachments is generated when running `!list`. This list is held until the current bust ends, in which the list is enumerated and each attachment is removed from disk. This list is overwritten if `!list` is called multiple times before `!bust`.