### PR TITLE
Sanitize user-provided artist and title tags if found

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,7 +203,9 @@ def song_format(
         # Ignore file and move on
         tags = None
 
-    # Sanitize tag contents
+    # Sanitize tag contents.
+    # We explicitly check for None here, as anything else means that the data was
+    # pulled from the audio.
     if artist is not None:
         artist = sanitize_tag(artist)
     if title is not None:

--- a/main.py
+++ b/main.py
@@ -39,6 +39,8 @@ EMBED_FIELD_VALUE_LIMIT = 1024
 LIST_EMBED_COLOR = 0xDD2E44
 # Color of "Now Playing" embed
 PLAY_EMBED_COLOR = 0x33B86B
+# The maximum character length of any song title or artist name
+MAXIMUM_SONG_METADATA_CHARACTERS = 1000
 
 # SETTINGS
 # How many seconds to wait in-between songs
@@ -146,6 +148,29 @@ async def on_message(message: Message):
         await command_stop()
 
 
+def sanitize_tag(tag_value: str) -> str:
+    """Sanitizes a tag value.
+
+    Sanitizes by:
+        * removing any newline characters.
+        * capping to 1000 characters total.
+
+    Args:
+        tag_value: The tag to sanitize (i.e. an artist or song name).
+
+    Returns:
+        The sanitized string.
+    """
+    # Remove any newlines
+    tag_value = "".join(tag_value.splitlines())
+
+    if len(tag_value) > MAXIMUM_SONG_METADATA_CHARACTERS:
+        # Cap the length of the string and append an ellipsis
+        tag_value = tag_value[: MAXIMUM_SONG_METADATA_CHARACTERS - 1] + "…"
+
+    return tag_value
+
+
 def song_format(
     local_filepath: str, filename: str, artist_fallback: Optional[str] = None
 ) -> str:
@@ -166,8 +191,8 @@ def song_format(
         A string presenting the given song information in a human-readable way.
     """
     content = ""
-    artist = ""
-    title = ""
+    artist = None
+    title = None
 
     # load tags
     try:
@@ -177,6 +202,12 @@ def song_format(
     except MutagenError:
         # Ignore file and move on
         tags = None
+
+    # Sanitize tag contents
+    if artist is not None:
+        artist = sanitize_tag(artist)
+    if title is not None:
+        title = sanitize_tag(title)
 
     # Display in the format <Artist-tag> - <Title-tag>
     # If no artist tag use fallback if valid. Otherwise, skip artist


### PR DESCRIPTION
Fixes #64.

From this:
![image](https://user-images.githubusercontent.com/1342360/152045967-0f0d9812-c2f8-44bd-a515-f658f7acf099.png)

To this:
![image](https://user-images.githubusercontent.com/1342360/152045949-22aaf928-c4f2-4e37-933e-0f049e77bf2c.png)

1000 characters for either a song or title was chosen arbitrarily. With both, the output would look like:

![image](https://user-images.githubusercontent.com/1342360/152046194-cc97e8df-817b-4233-852e-e02b75fd0f78.png)

which is kind of long, but still within the range of what I'd consider funny over bot-breaking.