### PR TITLE
Check for the presence of one or more arguments, not >1

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ async def on_message(message: Message):
 
         command_args = message.content.split()[1:]
         skip_count = 0
-        if len(command_args) > 1:
+        if command_args:
             try:
                 # Expects a positive integer
                 bust_index = int(command_args[0])


### PR DESCRIPTION
Fixes #70 

Introduced in https://github.com/anoadragon453/busty/pull/42. Missed this during code review :sob: 

