### PR TITLE
Fix audio.tags nonetype bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ def get_cover_art(filename: str) -> Optional[File]:
         image_data = None
         audio = MutagenFile(filename)
 
-        # In each case, ensure audio.tags is not None to avoid what seems to be a mutagen bug
+        # In each case, ensure audio.tags is not None
         if isinstance(audio, ID3FileType):
             if audio.tags:
                 for tag_name, tag_value in audio.tags.items():
@@ -256,6 +256,10 @@ def get_cover_art(filename: str) -> Optional[File]:
     except MutagenError:
         # Ignore file and move on
         return None
+    except Exception as e:
+        print(f'Unknown error reading cover art for {filename}:', e)
+        return None
+
 
     # Make sure it doesn't go over 8MB
     # This is a safe lower bound on the Discord upload limit of 8MiB

--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ def get_cover_art(filename: str) -> Optional[File]:
         image_data = None
         audio = MutagenFile(filename)
 
-        # In each case, ensure audio.tags is not None
+        # In each case, ensure audio tags are not None or empty
         if isinstance(audio, ID3FileType):
             if audio.tags:
                 for tag_name, tag_value in audio.tags.items():

--- a/main.py
+++ b/main.py
@@ -257,9 +257,8 @@ def get_cover_art(filename: str) -> Optional[File]:
         # Ignore file and move on
         return None
     except Exception as e:
-        print(f'Unknown error reading cover art for {filename}:', e)
+        print(f"Unknown error reading cover art for {filename}:", e)
         return None
-
 
     # Make sure it doesn't go over 8MB
     # This is a safe lower bound on the Discord upload limit of 8MiB


### PR DESCRIPTION
Closes #73. During Busty's 3, a certain [mp3 file](https://cdn.discordapp.com/attachments/938166238193025124/938258064224714752/ImAGhost.mp3) caused busty to hang forever. The reason was because in the `get_cover_art()` function, the `audio` variable tested True for `isinstance(audio, ID3FileType)` but `audio.tags` was `None`. From what I can tell, this is a bug in mutagen itself, as the [documentation](https://mutagen.readthedocs.io/en/latest/user/classes.html?highlight=filetype#tags) seems to suggest that this field should always be of type `Tags`. This PR checks that attributes of MutagenFile are not `None` before using them.