### PR TITLE
Run cleanup tasks on bot shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ async def on_ready():
 async def close():
     """Perform some cleanup tasks on bot shutdown"""
     try:
-        # Restore the original nickname if it was changed.
+        # Restore the original nickname if it was changed
         await maybe_restore_original_nick()
 
         # Delete any downloaded attachments from the last bust
@@ -111,8 +111,8 @@ async def maybe_restore_original_nick():
 
 def delete_saved_attachments():
     """Delete any attachments saved during the current bust."""
-    # This will run at any point the bot shuts down, even when outside
-    # outside of a bust when current_bust_content is None
+    # This will run at any point the bot shuts down. Note that outside of a bust,
+    # current_bust_content is None
     if not current_bust_content:
         return
 


### PR DESCRIPTION
Closes #68.

A bot can override the `close` method of a `nextcord.Client` in order to run cleanup tasks on client shutdown.

Implementing this function will override nextcord's own `Client.close()`; the implementation of which is shown here (and explains how nextcord will disconnect from VC's on shutdown): https://github.com/nextcord/nextcord/blob/8d82a0858f8440c2b62f92b8e8e6d79b6873c684/nextcord/client.py#L637-L642

Overriding this function has the benefit of allowing us to run our own code on shutdown, but also means that the original `close` method linked about *doesn't* run. I've attempted to run this manually, though this oddly leaves to infinite recursion and strange behaviour.

Ideally we'd also run the original `close` method. But for now, taking the vc disconnect feature seems to result in the desired behaviour.

This PR also pulls the bot nickname restoration and attachment cleanup tasks into their own helper methods.