### PR TITLE
Fix Busty raising an exception whenever she is direct messaged

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from nextcord import (
     Forbidden,
     HTTPException,
     Intents,
+    Member,
     Message,
     NotFound,
     TextChannel,
@@ -87,6 +88,9 @@ async def on_ready():
 @client.event
 async def on_message(message: Message):
     if message.author == client.user:
+        return
+
+    if not isinstance(message.author, Member):
         return
 
     for role in message.author.roles:


### PR DESCRIPTION
`message.author` is of class `Member` if the message was sent in a server, and of class `User` if the message was sent via a DM. Only the `Member` class has the field `roles`,  but in `on_message()` we access `message.author.roles` without checking to see if the type is `Member` or `User`.