### PR TITLE
Add development documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,30 @@ The expected flow for running a bust is:
 
 Users must have the `bangermeister` role to use commands by default, though this role can
 be modified by passing the `BUSTY_DJ_ROLE` environment variable.
+
+## Development
+
+If you'd like to help Busty in her quest, consider working on one of the
+[currently open issues](https://github.com/anoadragon453/busty). Before you do,
+please double-check that a pull request for the issue
+[does not already exist](https://github.com/anoadragon453/busty/pulls).
+
+### Testing your changes
+
+Busty does not currently feature any automated testing. Testing is carried out
+manually, typically in one's own test Discord guild.
+
+Once you have implemented your change, please ensure that [known commands](#command-reference),
+listing tracks and playing songs all work with your change. Pull requests are
+additionally tested by reviewers before merging them, but we're only human.
+
+### Linting
+
+Once you have implemented your feature and tested that it works, you'll need to
+ensure your code is properly formatted. Running `./scripts-dev/lint.sh` will
+check this for you and - in most cases - fix any style issues automatically.
+
+Otherwise, some issues may need to be fixed manually. These will be printed when
+`lint.sh` is run. They must be fixed before your PR will be accepted. If you
+are unable to figure out how to appease the linter, simply post and mark your
+pull request as a draft and ask for help in a comment.


### PR DESCRIPTION
So that new contributors have an easier path forwards.

Instructions on installing the dependencies to run `./scripts-dev/lint.sh` are intentionally excluded, as they are added in https://github.com/anoadragon453/busty/pull/86 instead.