### PR TITLE
Add a requirements.txt equivalent for dev dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U isort==5.10.1 flake8==4.0.1 flake8-comprehensions==3.7.0 black==21.12b0
+        # Install linting tools
+        pip install -r dev-requirements.txt
 
     - name: Check import statement sorting
       run: |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ If you'd like to help Busty in her quest, consider working on one of the
 please double-check that a pull request for the issue
 [does not already exist](https://github.com/anoadragon453/busty/pulls).
 
+### Installing the development dependencies
+
+Some extra python modules are necessary when developing for Busty. These are
+contained in the `dev-requirements.txt` file. To install them, run:
+
+```shell
+# Activate the virtualenv if not already done so
+source env/bin/activate
+
+# Install development dependencies
+pip install -r dev-requirements.txt
+```
+
 ### Testing your changes
 
 Busty does not currently feature any automated testing. Testing is carried out

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ please double-check that a pull request for the issue
 
 ### Installing the development dependencies
 
-Some extra python modules are necessary when developing for Busty. These are
+Some extra Python modules are necessary when developing for Busty. These are
 contained in the `dev-requirements.txt` file. To install them, run:
 
 ```shell

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+# Tools required to lint the codebase
+isort==5.10.1
+flake8==4.0.1
+flake8-comprehensions==3.7.0
+black==21.12b0


### PR DESCRIPTION
The result of this is that one no longer needs to dig into the CI config in order to figure out how to run the linting script.

Depends on https://github.com/anoadragon453/busty/pull/85. Reviewable commit-by-commit.