### PR TITLE
Google Form generation with Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The expected flow for running a bust is:
 1. `!bust [<song #>]` - Join the vc/stage that the user who ran this command is currently in, and plays the tracks in the channel in order. The user must be in a vc or stage for this to work. Specifying a song index will skip to that index before playing.
 1. `!skip` - Skips the current track :scream: 
 1. `!stop` - Stop busting early :scream: :scream: :scream: 
+1. `!form` - Show [Google Apps Script](https://developers.google.com/apps-script) code which will generate a Google Form that can be used for voting.
 
 Users must have the `bangermeister` role to use commands by default, though this role can
 be modified by passing the `BUSTY_DJ_ROLE` environment variable.

--- a/main.py
+++ b/main.py
@@ -139,6 +139,12 @@ async def on_message(message: Message):
 
         await command_play(message, skip_count)
 
+    elif message_text.startswith("!form"):
+        if not current_channel_content or not current_channel:
+            await message.channel.send("You need to use !list first, sugar.")
+            return
+        await command_form(message)
+
     elif message_text.startswith("!skip"):
         if not active_voice_client or not active_voice_client.is_playing():
             await message.channel.send("Nothing is playing.")
@@ -631,6 +637,43 @@ def pick_random_emoji() -> str:
     decoded_random_emoji = encoded_random_emoji.encode("Latin1").decode()
 
     return decoded_random_emoji
+
+
+async def command_form(message: Message):
+    # Escape strings so they can be assigned as literals within appscript
+    def escape_appscript(text: str):
+        return text.replace("\\", "\\\\").replace('"', '\\"')
+
+    # Constants in generated code, Mmke sure these strings are properly escaped
+    default_title = "Busty's Voting"
+    low_string = "OK"
+    high_string = "Masterpiece"
+    low_score = 0
+    high_score = 7
+
+    appscript = "function r(){"
+    # Setup and grab form
+    appscript += f'var f=FormApp.getActiveForm().setTitle("{default_title}");'
+    # Clear existing data on form
+    appscript += "f.getItems().forEach(i=>f.deleteItem(i));"
+    # Add new data to form TODO: properly escape double quotes and backslashes, etc
+    create_line = "[" + ",".join(
+        [
+            '"{}: {}"'.format(
+                escape_appscript(submit_message.author.display_name),
+                escape_appscript(song_format(local_filepath, attachment.filename)),
+            )
+            for submit_message, attachment, local_filepath in current_channel_content
+        ]
+    )
+    create_line += '].forEach(s=>f.addScaleItem().setTitle(s).setBounds({},{}).setLabels("{}","{}"))'.format(
+        low_score, high_score, low_string, high_string
+    )
+    create_line += "}"
+    appscript += create_line
+
+    # There is no way to escape ``` in a code block on Discord, so we replace ``` --> '''
+    await message.channel.send("```{}```".format(appscript.replace("```", "'''")))
 
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with

--- a/main.py
+++ b/main.py
@@ -35,6 +35,8 @@ from PIL import Image, UnidentifiedImageError
 EMBED_DESCRIPTION_LIMIT = 4096
 # Max number of characters in an embed field.value
 EMBED_FIELD_VALUE_LIMIT = 1024
+# Max number of character is a normal Disord message
+MESSAGE_LIMIT = 2000
 # Color of !list embed
 LIST_EMBED_COLOR = 0xDD2E44
 # Color of "Now Playing" embed
@@ -677,7 +679,12 @@ async def command_form(message: Message):
     appscript += create_line
 
     # There is no way to escape ``` in a code block on Discord, so we replace ``` --> '''
-    await message.channel.send("```{}```".format(appscript.replace("```", "'''")))
+    appscript = appscript.replace("```", "'''")
+
+    # Print message in chunks respecting character limit
+    chunk_size = MESSAGE_LIMIT - 6
+    for i in range(0, len(appscript), chunk_size):
+        await message.channel.send("```{}```".format(appscript[i : i + chunk_size]))
 
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ from PIL import Image, UnidentifiedImageError
 EMBED_DESCRIPTION_LIMIT = 4096
 # Max number of characters in an embed field.value
 EMBED_FIELD_VALUE_LIMIT = 1024
-# Max number of character is a normal Disord message
+# Max number of characters in a normal Disord message
 MESSAGE_LIMIT = 2000
 # Color of !list embed
 LIST_EMBED_COLOR = 0xDD2E44
@@ -641,12 +641,12 @@ def pick_random_emoji() -> str:
     return decoded_random_emoji
 
 
-async def command_form(message: Message):
+async def command_form(message: Message) -> None:
     # Escape strings so they can be assigned as literals within appscript
-    def escape_appscript(text: str):
+    def escape_appscript(text: str) -> str:
         return text.replace("\\", "\\\\").replace('"', '\\"')
 
-    # Constants in generated code, Mmke sure these strings are properly escaped
+    # Constants in generated code, Make sure these strings are properly escaped
     default_title = "Busty's Voting"
     low_string = "OK"
     high_string = "Masterpiece"
@@ -658,7 +658,7 @@ async def command_form(message: Message):
     appscript += f'var f=FormApp.getActiveForm().setTitle("{default_title}");'
     # Clear existing data on form
     appscript += "f.getItems().forEach(i=>f.deleteItem(i));"
-    # Add new data to form TODO: properly escape double quotes and backslashes, etc
+    # Add new data to form
     create_line = "[" + ",".join(
         [
             '"{}. {}: {}"'.format(

--- a/main.py
+++ b/main.py
@@ -659,11 +659,15 @@ async def command_form(message: Message):
     # Add new data to form TODO: properly escape double quotes and backslashes, etc
     create_line = "[" + ",".join(
         [
-            '"{}: {}"'.format(
+            '"{}. {}: {}"'.format(
+                index,
                 escape_appscript(submit_message.author.display_name),
                 escape_appscript(song_format(local_filepath, attachment.filename)),
             )
-            for submit_message, attachment, local_filepath in current_channel_content
+            for index, (submit_message, attachment, local_filepath) in enumerate(
+                current_channel_content,
+                1,
+            )
         ]
     )
     create_line += '].forEach(s=>f.addScaleItem().setTitle(s).setBounds({},{}).setLabels("{}","{}"))'.format(


### PR DESCRIPTION
Partially implements #12. The `!form` command (when run after `!list`) prints out Google Apps Script code which can be copied and pasted to automatically generate a voting form from the Apps Script code editor in your browser.

There is still in theory work to be done on this front, for example automatically generating the responses form and statistics, or even using the Google API to generate the form without any manual copying and pasting. However, this implements 95% of what would be nice to have, and is a self-contained feature.