### PR TITLE
Allow wav album art

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from mutagen import File as MutagenFile, MutagenError
 from mutagen.flac import FLAC, Picture
 from mutagen.id3 import ID3FileType, PictureType
 from mutagen.ogg import OggFileType
+from mutagen.wave import WAVE
 from nextcord import (
     Attachment,
     ChannelType,
@@ -261,7 +262,7 @@ def get_cover_art(filename: str) -> Optional[File]:
         audio = MutagenFile(filename)
 
         # In each case, ensure audio tags are not None or empty
-        if isinstance(audio, ID3FileType):
+        if isinstance(audio, ID3FileType) or isinstance(audio, WAVE):
             if audio.tags:
                 for tag_name, tag_value in audio.tags.items():
                     if (


### PR DESCRIPTION
The [WAVE](https://mutagen.readthedocs.io/en/latest/api/wave.html) filetype is (for some reason) not a subclass of [ID3FileType](https://mutagen.readthedocs.io/en/latest/api/id3.html#mutagen.id3.ID3FileType) in mutagen, even though its `tags` attribute is `mutagen.id3.ID3`. This short PR uses the existing ID3 code to handle wave files. This PR has been tested.