### PR TITLE
Fix a number of type hint errors

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,6 @@ isort==5.10.1
 flake8==4.0.1
 flake8-comprehensions==3.7.0
 black==21.12b0
+
+# type stubs
+types-pillow>=9.0  # should be kept in sync with pillow in requirements

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 import random
 from io import BytesIO
 from os import path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from mutagen import File as MutagenFile, MutagenError
 from mutagen.flac import FLAC, Picture
@@ -24,7 +24,9 @@ from nextcord import (
     Intents,
     Message,
     NotFound,
+    StageChannel,
     TextChannel,
+    VoiceChannel,
     VoiceClient,
 )
 from nextcord.utils import escape_markdown
@@ -333,7 +335,11 @@ async def command_stop() -> None:
 
 async def command_play(message: Message, skip_count: int = 0):
     # Join active voice call
-    voice_channels = message.guild.voice_channels + message.guild.stage_channels
+    voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
+        message.guild.voice_channels
+    )
+    voice_channels.extend(message.guild.stage_channels)
+
     if not voice_channels:
         await message.channel.send(
             "You need to be in an active voice or stage channel."

--- a/main.py
+++ b/main.py
@@ -85,12 +85,12 @@ client = Client(intents=intents)
 
 
 @client.event
-async def on_ready():
+async def on_ready() -> None:
     print("We have logged in as {0.user}.".format(client))
 
 
 @client.event
-async def on_message(message: Message):
+async def on_message(message: Message) -> None:
     if message.author == client.user:
         return
 

--- a/main.py
+++ b/main.py
@@ -333,7 +333,7 @@ async def command_stop() -> None:
         await bot_member.edit(nick=original_bot_nickname)
 
 
-async def command_play(message: Message, skip_count: int = 0):
+async def command_play(message: Message, skip_count: int = 0) -> None:
     # Join active voice call
     voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
         message.guild.voice_channels

--- a/main.py
+++ b/main.py
@@ -513,6 +513,10 @@ async def play_next_song(skip_count: int = 0) -> None:
 async def command_list(message: Message) -> None:
     target_channel = message.channel
 
+    if not isinstance(target_channel, TextChannel):
+        print(f"Unsupported channel type to !list: {type(target_channel)}")
+        return
+
     # If any channels were mentioned in the message, use the first from the list
     if message.channel_mentions:
         mentioned_channel = message.channel_mentions[0]

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from nextcord import (
     Forbidden,
     HTTPException,
     Intents,
+    Member,
     Message,
     NotFound,
     StageChannel,
@@ -94,8 +95,13 @@ async def on_message(message: Message) -> None:
     if message.author == client.user:
         return
 
-    # Do not process messages in DM channels
-    if message.guild is None:
+    # Do not process messages outside of guild text channels
+    if not isinstance(message.channel, TextChannel):
+        return
+
+    # The message author must be a guild member, so that we can
+    # check if they have the appropriate role below
+    if not isinstance(message.author, Member):
         return
 
     for role in message.author.roles:
@@ -644,7 +650,8 @@ async def scrape_channel_media(
 
             # Save file if not in cache
             if not os.path.exists(attachment_filepath):
-                await attachment.save(attachment_filepath)
+                # Type error fixed by https://github.com/nextcord/nextcord/pull/539
+                await attachment.save(os.path.join(attachment_filepath))  # type: ignore[arg-type]
 
             channel_media_attachments.append(
                 (

--- a/main.py
+++ b/main.py
@@ -538,7 +538,7 @@ async def command_list(message: Message) -> None:
     embed_description_prefix = "**Track Listing**\n"
 
     # List of embed descriptions to circumvent the Discord character embed limit
-    embed_description_list = []
+    embed_description_list: List[str] = []
     embed_description_current = ""
 
     for index, (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[[tool.mypy.overrides]]
+module = "mutagen.*"
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mutagen>=1.45.1
 nextcord[voice]>=2.0.0a6
-pillow>=9.0
+pillow>=9.0  # should be kept in sync with types-pillow in dev-requirements


### PR DESCRIPTION
Reduces the number of type errors found by [mypy](https://mypy.readthedocs.io/) across the codebase.

Takes us from:

<details>

<summary>before this PR</summary>

```
(venv) [user@izzy busty]$ mypy main.py --show-error-codes
main.py:9: error: Skipping analyzing "mutagen": module is installed, but missing library stubs or py.typed marker  [import]
main.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
main.py:10: error: Skipping analyzing "mutagen.flac": module is installed, but missing library stubs or py.typed marker  [import]
main.py:11: error: Skipping analyzing "mutagen.id3": module is installed, but missing library stubs or py.typed marker  [import]
main.py:12: error: Skipping analyzing "mutagen.ogg": module is installed, but missing library stubs or py.typed marker  [import]
main.py:13: error: Skipping analyzing "mutagen.wave": module is installed, but missing library stubs or py.typed marker  [import]
main.py:99: error: Item "User" of "Union[User, Member]" has no attribute "roles"  [union-attr]
main.py:326: error: Item "None" of "Optional[VoiceClient]" has no attribute "stop"  [union-attr]
main.py:330: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:331: error: Item "None" of "Optional[Member]" has no attribute "edit"  [union-attr]
main.py:336: error: Item "None" of "Optional[Guild]" has no attribute "voice_channels"  [union-attr]
main.py:336: error: Unsupported operand types for + ("List[VoiceChannel]" and "List[StageChannel]")  [operator]
main.py:336: note: Both left and right operands are unions
main.py:336: error: Item "None" of "Optional[Guild]" has no attribute "stage_channels"  [union-attr]
main.py:344: error: Item "None" of "Optional[Guild]" has no attribute "get_member"  [union-attr]
main.py:344: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:360: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:374: error: Item "None" of "Union[Member, None, Any]" has no attribute "display_name"  [union-attr]
main.py:384: error: Item "None" of "Optional[VoiceClient]" has no attribute "stop"  [union-attr]
main.py:408: error: Item "None" of "Optional[TextChannel]" has no attribute "guild"  [union-attr]
main.py:408: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:412: error: Item "None" of "Optional[VoiceClient]" has no attribute "disconnect"  [union-attr]
main.py:416: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:424: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:438: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:476: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:478: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:490: error: Item "None" of "Optional[VoiceClient]" has no attribute "play"  [union-attr]
main.py:504: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:519: error: Argument 1 to "scrape_channel_media" has incompatible type "Union[Union[TextChannel, Thread, DMChannel, PartialMessageable], GroupChannel]"; expected "TextChannel"  [arg-type]
main.py:531: error: Need type annotation for "embed_description_list" (hint: "embed_description_list: List[<type>] = ...")  [var-annotated]
main.py:598: error: Incompatible types in assignment (expression has type "Union[Union[TextChannel, Thread, DMChannel, PartialMessageable], GroupChannel]", variable has type "Optional[TextChannel]")  [assignment]
main.py:637: error: Argument 1 to "save" of "Attachment" has incompatible type "str"; expected "Union[BufferedIOBase, PathLike[Any]]"  [arg-type]
main.py:694: error: Item "None" of "Optional[List[Tuple[Message, Attachment, str]]]" has no attribute "__iter__" (not iterable)  [union-attr]
Found 32 errors in 1 file (checked 1 source file)
```
</details>

to

<details>

<summary>after this PR</summary>

```
(venv) [user@izzy busty]$ mypy main.py --show-error-codes
main.py:334: error: Item "None" of "Optional[VoiceClient]" has no attribute "stop"  [union-attr]
main.py:338: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:339: error: Item "None" of "Optional[Member]" has no attribute "edit"  [union-attr]
main.py:345: error: Item "None" of "Optional[Guild]" has no attribute "voice_channels"  [union-attr]
main.py:347: error: Item "None" of "Optional[Guild]" has no attribute "stage_channels"  [union-attr]
main.py:356: error: Item "None" of "Optional[Guild]" has no attribute "get_member"  [union-attr]
main.py:356: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:372: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:386: error: Item "None" of "Union[Member, None, Any]" has no attribute "display_name"  [union-attr]
main.py:396: error: Item "None" of "Optional[VoiceClient]" has no attribute "stop"  [union-attr]
main.py:420: error: Item "None" of "Optional[TextChannel]" has no attribute "guild"  [union-attr]
main.py:420: error: Item "None" of "Optional[ClientUser]" has no attribute "id"  [union-attr]
main.py:424: error: Item "None" of "Optional[VoiceClient]" has no attribute "disconnect"  [union-attr]
main.py:428: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:436: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:450: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:488: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:490: error: Item "None" of "Optional[TextChannel]" has no attribute "send"  [union-attr]
main.py:502: error: Item "None" of "Optional[VoiceClient]" has no attribute "play"  [union-attr]
main.py:516: error: Item "None" of "Union[Member, None, Any]" has no attribute "edit"  [union-attr]
main.py:711: error: Item "None" of "Optional[List[Tuple[Message, Attachment, str]]]" has no attribute "__iter__" (not iterable)  [union-attr]
Found 21 errors in 1 file (checked 1 source file)
```

</details>

The remaining type errors are due to use using `Optional[...]` types for all of our global variables. Invoking methods on variables that could potentially be `None` makes mypy upset.

Rather than add `is not None` checks everywhere, I think we can refactor our code to use less globals instead. I'll take discussion of this to a separate issue though.

Review commit-by-commit.

Related to #88.