### PR TITLE
Download files concurrently

### DIFF
--- a/main.py
+++ b/main.py
@@ -645,7 +645,7 @@ async def scrape_channel_media(
             )
 
     # Save all files if not in cache
-    async def dl_file(attachment, attachment_filepath: str) -> None:
+    async def dl_file(attachment: Attachment, attachment_filepath: str) -> None:
         if not os.path.exists(attachment_filepath):
             await attachment.save(attachment_filepath)
 

--- a/main.py
+++ b/main.py
@@ -636,10 +636,6 @@ async def scrape_channel_media(
                 ),
             )
 
-            # Save file if not in cache
-            if not os.path.exists(attachment_filepath):
-                await attachment.save(attachment_filepath)
-
             channel_media_attachments.append(
                 (
                     message,
@@ -647,6 +643,14 @@ async def scrape_channel_media(
                     attachment_filepath,
                 )
             )
+
+    # Save all files if not in cache
+    async def dl_file(attachment, attachment_filepath: str) -> None:
+        if not os.path.exists(attachment_filepath):
+            await attachment.save(attachment_filepath)
+
+    tasks = [asyncio.create_task(dl_file(at, fp)) for _, at, fp in channel_media_attachments]
+    await asyncio.wait(tasks)
 
     # Clear unused files in attachment directory
     used_files = {path for (_, _, path) in channel_media_attachments}

--- a/main.py
+++ b/main.py
@@ -716,9 +716,9 @@ async def scrape_channel_media(
     async def dl_file(attachment: Attachment, attachment_filepath: str) -> None:
         if os.path.exists(attachment_filepath):
             return
-        
+
         # Limit concurrent downloads
-        await with download_semaphore:
+        async with download_semaphore:
             await attachment.save(attachment_filepath)
 
     tasks = [

--- a/main.py
+++ b/main.py
@@ -649,7 +649,9 @@ async def scrape_channel_media(
         if not os.path.exists(attachment_filepath):
             await attachment.save(attachment_filepath)
 
-    tasks = [asyncio.create_task(dl_file(at, fp)) for _, at, fp in channel_media_attachments]
+    tasks = [
+        asyncio.create_task(dl_file(at, fp)) for _, at, fp in channel_media_attachments
+    ]
     await asyncio.wait(tasks)
 
     # Clear unused files in attachment directory

--- a/main.py
+++ b/main.py
@@ -714,10 +714,12 @@ async def scrape_channel_media(
 
     # Save all files if not in cache
     async def dl_file(attachment: Attachment, attachment_filepath: str) -> None:
-        await download_semaphore.acquire()
-        if not os.path.exists(attachment_filepath):
+        if os.path.exists(attachment_filepath):
+            return
+        
+        # Limit concurrent downloads
+        await with download_semaphore:
             await attachment.save(attachment_filepath)
-        download_semaphore.release()
 
     tasks = [
         asyncio.create_task(dl_file(at, fp)) for _, at, fp in channel_media_attachments

--- a/main.py
+++ b/main.py
@@ -786,7 +786,7 @@ async def command_form(message: Message) -> None:
     # Print message in chunks respecting character limit
     chunk_size = MESSAGE_LIMIT - 6
     for i in range(0, len(appscript), chunk_size):
-        await message.channel.send("```{}```".format(appscript[i: i + chunk_size]))
+        await message.channel.send("```{}```".format(appscript[i : i + chunk_size]))
 
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with


### PR DESCRIPTION
I ran `!list` on a channel with all Busty's 4 songs with versions of Busty which:
1. Started all async downloads simultaneously and then waiting for them all to finish (this commit)
2. For each async download, started it and then `await`ed for it to finish before moving to the next download

I cleared the attachments folder in between runs of each version to avoid caching speedups. I performed this entire process about 5-6 times, each time comparing the time of the download phase of both (1) and (2).

While my testing approach was maybe slightly unscientific version (1) was *always* faster than (2) (usually ~9 seconds total download time vs ~12).