### PR TITLE
Add volume multiplier to avoid clipping

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ MAXIMUM_SONG_METADATA_CHARACTERS = 1000
 # The maximum number of messages to scan for song submissions
 MAXIMUM_MESSAGES_TO_SCAN = 1000
 # Volume multiplier to avoid clipping on Discord
-VOLUME_MULTIPLIER = 0.75
+VOLUME_MULTIPLIER = 0.5
 
 # SETTINGS
 # How many seconds to wait in-between songs

--- a/main.py
+++ b/main.py
@@ -49,6 +49,8 @@ PLAY_EMBED_COLOR = 0x33B86B
 MAXIMUM_SONG_METADATA_CHARACTERS = 1000
 # The maximum number of messages to scan for song submissions
 MAXIMUM_MESSAGES_TO_SCAN = 1000
+# Volume multiplier to avoid clipping on Discord
+VOLUME_MULTIPLIER = 0.75
 
 # SETTINGS
 # How many seconds to wait in-between songs
@@ -542,7 +544,10 @@ async def play_next_song(skip_count: int = 0) -> None:
         asyncio.run_coroutine_threadsafe(play_next_song(), client.loop)
 
     # Play song
-    active_voice_client.play(FFmpegPCMAudio(local_filepath), after=ffmpeg_post_hook)
+    active_voice_client.play(
+        FFmpegPCMAudio(local_filepath, options=f"-filter:a volume={VOLUME_MULTIPLIER}"),
+        after=ffmpeg_post_hook,
+    )
 
     # Change the name of the bot to that of the currently playing song.
     # This allows people to quickly see which song is currently playing.


### PR DESCRIPTION
Closes #101. Adds a hard-coded volume multiplier. ~Currently marked as draft because I cannot find the optimal multiplier myself, as the clipping issue seems to only be reproducible on Windows. At some point I'll get in call with a Windows user to figure this out.~

Bobby and I found that the moment clipping becomes unnoticeable was setting the coefficient just over 0.5, so I set it to 0.5 since it seems like the type of number that whatever technical error is happening would actually need. Despite the volume multiplier being 0.5 down from 1, the audio is actually subjectively barely different in volume (some psychoacoustic log scaling something something).