### PR TITLE
Request the "message content" intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,22 @@ And install the dependencies:
 pip install -r requirements.txt
 ```
 
-To install an additional set of python dependencies for speeding up the bot, install the `nextcord[speed]` package as well. You may need to install additional system packages.
+To install an additional set of python dependencies for speeding up the bot, install the
+`nextcord[speed]` package as well.You may need to install additional system packages.
 
 ## Configure
 
-You'll need to create a Discord app, add a bot component, and copy the bot token.
-Ensure that the environment variable `BUSTY_DISCORD_TOKEN` contains the bot token when running the bot.
-Then, add the bot to your desired Discord server.
+You'll need to create a Discord app, and add a bot component. **Ensure the bot has the
+"Server Members Intent" and "Message Content Intent"** options enabled, otherwise the bot
+will not function correctly. Note that this will limit your bot to participating in 100
+servers maximum, unless you verify your bot with Discord.
 
-The complete list of environment variable configuration options is
+Copy the bot token, and ensure that the environment variable `BUSTY_DISCORD_TOKEN` contains
+the bot token when running the bot.
+
+Finally, add the bot to your desired Discord server.
+
+The complete list of environment variable configuration options is:
 1. `BUSTY_DISCORD_TOKEN` - Discord bot API token (required)
 2. `BUSTY_COOLDOWN_SECS` - Number of seconds between songs (default = 10)
 3. `BUSTY_ATTACHMENT_DIR` - Directory to save attachments (default = attachments)

--- a/main.py
+++ b/main.py
@@ -86,7 +86,11 @@ emoji_list = list(emoji_dict.values())
 
 # This is necessary to query server members
 intents = Intents.default()
+# To fetch guild member information.
+# Privileged intent. Requires enabling in Discord Developer Portal.
 intents.members = True
+# To be able to read message content.
+intents.message_content = True
 
 # Set up the Discord client. Connecting to Discord is done at
 # the bottom of this file.


### PR DESCRIPTION
As of August 31st 2022, Discord will require bots to register an explicit intent in message content in order to receive it. The current beta versions of nextcord will thus only return an empty str for `Message.content` unless the `message_content` intent is enabled. See https://docs.nextcord.dev/en/latest/intents.html#what-happened-to-my-message-commands for further details.

This change allows the bot to function on nextcord>=v2.0.0b1.