### PR TITLE
Send a message in the channel if song playback fails in some cases

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,9 +116,6 @@ async def on_ready() -> None:
 
 @client.event
 async def on_close() -> None:
-    # Unpin current "now playing" message if it exists
-    if now_playing_msg:
-        await try_set_pin(now_playing_msg, False)
     # Finish current bust (if exists) as if it were stopped
     await finish_bust(say_goodbye=False)
 
@@ -460,6 +457,7 @@ async def finish_bust(say_goodbye: bool = True) -> None:
     global current_channel_content
     global current_channel
     global total_song_len
+    global now_playing_msg
 
     # Disconnect from voice if necessary
     if active_voice_client and active_voice_client.is_connected():
@@ -469,6 +467,11 @@ async def finish_bust(say_goodbye: bool = True) -> None:
     if original_bot_nickname and current_channel:
         bot_member = current_channel.guild.get_member(client.user.id)
         await bot_member.edit(nick=original_bot_nickname)
+
+    # Unpin the currently playing song message if one is pinned
+    if now_playing_msg:
+        await try_set_pin(now_playing_msg, False)
+        now_playing_msg = None
 
     if say_goodbye:
         embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"

--- a/main.py
+++ b/main.py
@@ -642,8 +642,6 @@ async def log_track_playback_exception(e: BaseException, track_info: str) -> Non
         e: The exception to log.
         track_info: The title of the song.
     """
-    global now_playing_msg
-
     # Log the exception
     print("Track playback quit with error:", e)
 


### PR DESCRIPTION
Closes #114. We now stop the bust if an exception is raised by nextcord during playback, log the exception and message the channel about it (rather than playback simply stopping silently).

To users, this looks like:

![image](https://user-images.githubusercontent.com/1342360/178066711-b9f98f80-80c9-4479-b9bb-e963da9caf20.png)

Admins would then go check the traceback and decide whether the audio file is worth attempting to play again or not (or to skip and potentially try a re-encoded version at the end of the bust).

---

Note that I haven't dug too deeply into `nextcord.AudioPlayer` to see what exact exceptions may end up actually being passed to `ffmpeg_post_hook`, but this PR attempts to handle any all the same.

On top of exceptions raised by the above, I think it may be nice to handle *any* exception (even ones we raise) during a bust in the same manner, so I've factored the code out to a separate function. This PR doesn't attempt to catch any other exceptions yet though.