### PR TITLE
Create the whole form automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ The expected flow for running a bust is:
 ### Command Reference
 
 1. `!list [<channel>]` - Download and list all media sent in the current text channel. Specifying a channel will cause songs to be pulled from that channel instead. This must be run before `!bust`.
-1. `!bust [<song #>]` - Join the vc/stage that the user who ran this command is currently in, and plays the tracks in the channel in order. The user must be in a vc or stage for this to work. Specifying a song index will skip to that index before playing.
-1. `!skip` - Skips the current track :scream: 
-1. `!stop` - Stop busting early :scream: :scream: :scream: 
-1. `!form` - Show [Google Apps Script](https://developers.google.com/apps-script) code which will generate a Google Form that can be used for voting.
+2. `!bust [<song #>]` - Join the vc/stage that the user who ran this command is currently in, and plays the tracks in the channel in order. The user must be in a vc or stage for this to work. Specifying a song index will skip to that index before playing.
+3. `!skip` - Skips the current track :scream: 
+4. `!stop` - Stop busting early :scream: :scream: :scream: 
+5. `!form [<google drive image url>]` - Show [Google Apps Script](https://developers.google.com/apps-script) code which will generate a Google Form that can be used for voting. If an image URL is provided, the image will be included at the end of the form. To retrieve an image URL, in Google Drive, right-click the image file -> get link -> copy link.
 
 Users must have the `bangermeister` role to use commands by default, though this role can
 be modified by passing the `BUSTY_DJ_ROLE` environment variable.

--- a/main.py
+++ b/main.py
@@ -885,6 +885,13 @@ async def command_form(
     for i in range(0, len(appscript), chunk_size):
         await message.channel.send("```js\n{}```".format(appscript[i : i + chunk_size]))
 
+    # Tell the user how to generate the form
+    await message.channel.send(
+        "Copy/paste the above code into a new appscript project (replace anything already there). "
+        "Then click Save, and Run: https://script.google.com/home/projects/create\n\n"
+        "Authorize the project to use your Google Account when prompted. Click Advanced -> Go to ..."
+    )
+
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with
 # a valid Discord bot access token.

--- a/main.py
+++ b/main.py
@@ -835,8 +835,6 @@ async def command_form(
     appscript = "function r(){"
     # Setup and grab form
     appscript += f'var f=FormApp.create("{form_title}");'
-    # Clear existing data on form
-    appscript += "f.getItems().forEach(i=>f.deleteItem(i));"
     # Add questions to form
     appscript += "[" + ",".join(
         [

--- a/main.py
+++ b/main.py
@@ -813,7 +813,9 @@ def pick_random_emoji() -> str:
     return decoded_random_emoji
 
 
-async def command_form(message: Message, google_drive_image_link: Optional[str] = None) -> None:
+async def command_form(
+    message: Message, google_drive_image_link: Optional[str] = None
+) -> None:
     # Escape strings so they can be assigned as literals within appscript
     def escape_appscript(text: str) -> str:
         return text.replace("\\", "\\\\").replace('"', '\\"')
@@ -856,18 +858,24 @@ async def command_form(message: Message, google_drive_image_link: Optional[str] 
 
     if google_drive_image_link:
         # Extract image file ID from the passed link
-        file_id_matches = re.match(r"https://drive.google.com/file/d/(.+)/view", google_drive_image_link)
+        file_id_matches = re.match(
+            r"https://drive.google.com/file/d/(.+)/view", google_drive_image_link
+        )
         if file_id_matches:
             file_id = file_id_matches.group(1)
 
             # Add an image to the form
-            appscript += f';f.addImageItem().setImage(DriveApp.getFileById("{file_id}"))'
+            appscript += (
+                f';f.addImageItem().setImage(DriveApp.getFileById("{file_id}"))'
+            )
 
     # Add comments/suggestions to form
     appscript += ";f.addParagraphTextItem().setTitle('Comments/suggestions')"
 
     # Print links to the form
-    appscript += ';console.log("Edit: "+f.getEditUrl()+"\\n\\nPublished: "+f.getPublishedUrl());'
+    appscript += (
+        ';console.log("Edit: "+f.getEditUrl()+"\\n\\nPublished: "+f.getPublishedUrl());'
+    )
 
     # Close appscript main function
     appscript += "}"

--- a/main.py
+++ b/main.py
@@ -861,7 +861,7 @@ async def command_form(message: Message) -> None:
     # Print message in chunks respecting character limit
     chunk_size = MESSAGE_LIMIT - 6
     for i in range(0, len(appscript), chunk_size):
-        await message.channel.send("```{}```".format(appscript[i : i + chunk_size]))
+        await message.channel.send("```js\n{}```".format(appscript[i : i + chunk_size]))
 
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with

--- a/main.py
+++ b/main.py
@@ -825,7 +825,7 @@ async def command_form(message: Message) -> None:
 
     appscript = "function r(){"
     # Setup and grab form
-    appscript += f'var f=FormApp.getActiveForm().setTitle("{form_title}");'
+    appscript += f'var f=FormApp.create("{form_title}");'
     # Clear existing data on form
     appscript += "f.getItems().forEach(i=>f.deleteItem(i));"
     # Add questions to form
@@ -849,6 +849,9 @@ async def command_form(message: Message) -> None:
 
     # Add comments/suggestions to form
     appscript += ";f.addParagraphTextItem().setTitle('Comments/suggestions')"
+
+    # Print links to the form
+    appscript += ';console.log("Edit: "+f.getEditUrl()+"\\n\\nPublished: "+f.getPublishedUrl());'
 
     # Close appscript main function
     appscript += "}"

--- a/main.py
+++ b/main.py
@@ -881,7 +881,7 @@ async def command_form(
     appscript = appscript.replace("```", "'''")
 
     # Print message in chunks respecting character limit
-    chunk_size = MESSAGE_LIMIT - 6
+    chunk_size = MESSAGE_LIMIT - 9
     for i in range(0, len(appscript), chunk_size):
         await message.channel.send("```js\n{}```".format(appscript[i : i + chunk_size]))
 


### PR DESCRIPTION
This PR:

* Has the google appscript create (and name) the form itself, instead of needing to create one manually first.
* Adds the image itself. Use `!form link_to_gdrive_image` when using the form command.
* Prints links to the editable version of the form, and the public version, for easy sharing.
* Adds syntax highlighting to the code. This isn't necessary, but is nice if you need to quickly scan the golfed code for any reason.

After this PR, the workflow for creating a form is:

1. Pick an image from google drive (right click on the image->get link->copy link)
2. Run `!form https://drive.google.com/file/d/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/view?usp=sharing`
3. Copy/paste the code into [a new google appscript file](https://script.google.com/home)
4. Save and Run (Ctrl-S, Ctrl-R). Wait.
5. Copy/paste the published link (check it first) to Discord.

The execution log looks like:

![image](https://user-images.githubusercontent.com/1342360/185021163-27f19caa-0f25-4be1-b1a3-ece768174bdc.png)

Downsides:
* You need to move the form to the right folder afterwards. But this can be done outside of the form-creation rush.
    * We could theoretically automate this too (by adding the folder ID as an env var).
* You get a scarier warning about running the script as it now has the ability (via DriveApp) to create forms instead of just modifying existing ones. You can skip the warning though.
* Running the form is no longer idempotent. Running it multiple times will cause a new form to be created each time. This only results in clutter of your google drive though, which is not much of an issue.