### PR TITLE
Fix emoji display

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -33,4 +33,4 @@ dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
 # The default list is expected to be stored at `./emoji_list.py`.
 emoji_filepath = os.environ.get("BUSTY_CUSTOM_EMOJI_FILEPATH", "emoji_list")
 # List of emoji for pulling random emoji
-emoji_list = list(__import__(emoji_filepath).DISCORD_TO_UNICODE)
+emoji_list = list(__import__(emoji_filepath).DISCORD_TO_UNICODE.values())


### PR DESCRIPTION
It turns out the single "logic change" in #125 had a bug I didn't notice, it was using emoji names instead of emoji themselves.

![image](https://user-images.githubusercontent.com/6956898/185781876-a703cd2f-6785-491a-8836-ee8e508dbf8a.png)
