### PR TITLE
Decouple BustController

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -21,18 +21,21 @@ import config
 import discord_utils
 import song_utils
 
+
 # Allow only one async routine to calculate !list at a time
 list_task_control_lock = asyncio.Lock()
 
 
 class BustController:
-    def __init__(self, client: Client):
+    def __init__(
+        self,
+        client: Client,
+        current_channel_content: List[Tuple[Message, Attachment, str]],
+        current_channel: TextChannel,
+    ):
 
         # The actively connected voice client
-        self.active_voice_client: Optional[VoiceClient] = None
-        # The nickname of the bot. We need to store it as it will be
-        # changed while songs are being played.
-        self.original_bot_nickname: str = None
+        self.voice_client: Optional[VoiceClient] = None
         # Currently pinned "now playing" message ID
         self.now_playing_msg: Optional[Message] = None
         # Keep track of the coroutine used to play the next track, which is active while
@@ -40,25 +43,45 @@ class BustController:
         # stopping playback is requested.
         self.play_next_task: Optional[asyncio.Task] = None
 
+        # The nickname of the bot. We need to store it as it will be
+        # changed while songs are being played.
+        self.original_bot_nickname: str = ""
+
         # The channel to send messages in
-        self.current_channel: Optional[TextChannel] = None
+        self.current_channel: TextChannel = current_channel
         # The media in the current channel
-        self.current_channel_content: Optional[
-            List[Tuple[Message, Attachment, str]]
-        ] = None
-        # Total length of all songs in seconds
-        self.total_song_len: Optional[float] = None
+        self.current_channel_content: List[
+            Tuple[Message, Attachment, str]
+        ] = current_channel_content
         # When play_next_task.cancel() is called, it is only actually cancelled on unsuspend
         # so play_next_task.cancelled() may return False.
         # We use this variable to keep track of /actual/ cancelled state
-        self.play_next_cancelled: Optional[bool] = False
+        self.play_next_cancelled: bool = False
         # Client object
         self.client: Client = client
+
+        # Calculate total length of all songs in seconds
+        self.total_song_len: float = 0.0
+        for _, _, local_filepath in self.current_channel_content:
+            song_len = song_utils.get_song_length(local_filepath)
+            if song_len:
+                self.total_song_len += song_len
+
+        self._finished: bool = False
+
+    def active(self) -> bool:
+        return self.voice_client and self.voice_client.is_connected()
+
+    def finished(self) -> bool:
+        # TODO: This message should become unnecessary once for-refactor is done
+        # See comment in main.py
+        return self._finished
 
     async def stop(self) -> None:
         """Stop playing music."""
         self.play_next_cancelled = True
-        self.play_next_task.cancel()
+        if self.play_next_task:
+            self.play_next_task.cancel()
         await self.finish(say_goodbye=False)
 
     async def play(self, message: Message, skip_count: int = 0) -> None:
@@ -85,7 +108,7 @@ class BustController:
             # We found a voice channel that the author is in.
             # Join the voice channel.
             try:
-                self.active_voice_client = await voice_channel.connect()
+                self.voice_client = await voice_channel.connect()
 
                 # If this is a stage voice channel, ensure that we are currently speaking.
                 if voice_channel.type == ChannelType.stage_voice:
@@ -122,7 +145,8 @@ class BustController:
     def skip(self) -> None:
         # Stop any currently playing song
         # The next song will play automatically.
-        self.active_voice_client.stop()
+        if self.voice_client:
+            self.voice_client.stop()
 
     async def finish(self, say_goodbye: bool = True) -> None:
         """End the current bust.
@@ -132,13 +156,17 @@ class BustController:
                 will be ended silently.
         """
         # Disconnect from voice if necessary
-        if self.active_voice_client and self.active_voice_client.is_connected():
-            await self.active_voice_client.disconnect()
+        if self.voice_client and self.voice_client.is_connected():
+            await self.voice_client.disconnect()
 
         # Restore the bot's original guild nickname (if it had one)
         if self.original_bot_nickname and self.current_channel:
             bot_member = self.current_channel.guild.get_member(self.client.user.id)
             await bot_member.edit(nick=self.original_bot_nickname)
+
+        # Unpin current "now playing" message if it exists
+        if self.now_playing_msg:
+            await discord_utils.try_set_pin(self.now_playing_msg, False)
 
         if say_goodbye:
             embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
@@ -154,11 +182,9 @@ class BustController:
             await self.current_channel.send(embed=embed)
 
         # Clear variables relating to current bust
-        self.active_voice_client = None
-        self.original_bot_nickname = None
-        self.current_channel_content = None
-        self.current_channel = None
-        self.total_song_len = None
+        self.voice_client = None
+        self.original_bot_nickname = ""
+        self._finished = True
 
     async def play_next_song(self, skip_count: int = 0) -> None:
         if not self.current_channel_content:
@@ -212,6 +238,7 @@ class BustController:
                 more_info = more_info[: config.EMBED_FIELD_VALUE_LIMIT - 1] + "…"
             embed.add_field(name="More Info", value=more_info, inline=False)
 
+        # Add cover art and send
         cover_art = song_utils.get_cover_art(local_filepath)
         if cover_art is not None:
             embed.set_image(url=f"attachment://{cover_art.filename}")
@@ -239,7 +266,7 @@ class BustController:
                 self.play_next_coro()
 
         # Play song
-        self.active_voice_client.play(
+        self.voice_client.play(
             FFmpegPCMAudio(
                 local_filepath, options=f"-filter:a volume={config.VOLUME_MULTIPLIER}"
             ),
@@ -261,21 +288,31 @@ class BustController:
         bot_member = self.current_channel.guild.get_member(self.client.user.id)
         await bot_member.edit(nick=new_nick)
 
-    async def list(self, message: Message) -> None:
-        target_channel = message.channel
 
-        if not isinstance(target_channel, TextChannel):
-            print(f"Unsupported channel type to !list: {type(target_channel)}")
-            return
+async def create_controller(client, message: Message) -> Optional[BustController]:
+    """Attempt to create a BustController given a channel list command"""
+    command_success = "\N{THUMBS UP SIGN}"
+    command_fail = "\N{OCTAGONAL SIGN}"
 
-        # If any channels were mentioned in the message, use the first from the list
-        if message.channel_mentions:
-            mentioned_channel = message.channel_mentions[0]
-            if isinstance(mentioned_channel, TextChannel):
-                target_channel = mentioned_channel
-            else:
-                await message.channel.send("That isn't a text channel.")
-                return
+    # Ensure two scrapes aren't making/deleting files at the same time
+    if list_task_control_lock.locked():
+        await message.add_reaction(command_fail)
+        return None
+
+    # Ensure target channel is text
+    target_channel = message.channel
+    # If any channels were mentioned in the message, use the first from the list
+    if message.channel_mentions:
+        target_channel = message.channel_mentions[0]
+
+    if not isinstance(target_channel, TextChannel):
+        print(f"Cannot create controller for {type(target_channel)}")
+        await message.add_reaction(command_fail)
+        return None
+
+    await message.add_reaction(command_success)
+
+    async with list_task_control_lock:
         # Scrape all tracks in the target channel and list them
         channel_media_attachments = await discord_utils.scrape_channel_media(
             target_channel
@@ -284,7 +321,7 @@ class BustController:
         # Break on no songs to list
         if len(channel_media_attachments) == 0:
             await message.channel.send("There aren't any songs there.")
-            return
+            return None
 
         # Title of !list embed
         embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
@@ -353,14 +390,5 @@ class BustController:
             for list_message in reversed(message_list):
                 await discord_utils.try_set_pin(list_message, True)
 
-        # Update global channel content
-        self.current_channel_content = channel_media_attachments
-
-        self.current_channel = target_channel
-
-        # Calculate total length of all songs
-        self.total_song_len = 0
-        for _, _, local_filepath in channel_media_attachments:
-            song_len = song_utils.get_song_length(local_filepath)
-            if song_len:
-                self.total_song_len += song_len
+        # Construct and return controller
+        return BustController(client, channel_media_attachments, target_channel)

--- a/src/bust.py
+++ b/src/bust.py
@@ -21,346 +21,354 @@ import config
 import discord_utils
 import song_utils
 
+# GLOBAL VARIABLES
+# The channel to send messages in
+current_channel: Optional[TextChannel] = None
+# The media in the current channel
+current_channel_content: Optional[List[Tuple[Message, Attachment, str]]] = None
+# The actively connected voice client
+active_voice_client: Optional[VoiceClient] = None
+# The nickname of the bot. We need to store it as it will be
+# changed while songs are being played.
+original_bot_nickname: Optional[str] = None
 # Allow only one async routine to calculate !list at a time
 list_task_control_lock = asyncio.Lock()
+# Total length of all songs in seconds
+total_song_len: Optional[float]
+# Currently pinned "now playing" message ID
+now_playing_msg: Optional[Message] = None
+# Keep track of the coroutine used to play the next track, which is active while
+# waiting in the intermission between songs. This task should be interrupted if
+# stopping playback is requested.
+play_next_task: Optional[asyncio.Task] = None
+# When play_next_task.cancel() is called, it is only actually cancelled on unsuspend
+# so play_next_task.cancelled() may return False.
+# We use this variable to keep track of /actual/ cancelled state
+play_next_cancelled: bool = False
+# Client object
+client: Client = None
 
 
-class BustController:
-    def __init__(self, client: Client):
+async def command_stop() -> None:
+    """Stop playing music."""
+    global play_next_cancelled
+    play_next_cancelled = True
+    play_next_task.cancel()
+    await finish_bust(say_goodbye=False)
 
-        # The actively connected voice client
-        self.active_voice_client: Optional[VoiceClient] = None
-        # The nickname of the bot. We need to store it as it will be
-        # changed while songs are being played.
-        self.original_bot_nickname: str = None
-        # Currently pinned "now playing" message ID
-        self.now_playing_msg: Optional[Message] = None
-        # Keep track of the coroutine used to play the next track, which is active while
-        # waiting in the intermission between songs. This task should be interrupted if
-        # stopping playback is requested.
-        self.play_next_task: Optional[asyncio.Task] = None
 
-        # The channel to send messages in
-        self.current_channel: Optional[TextChannel] = None
-        # The media in the current channel
-        self.current_channel_content: Optional[
-            List[Tuple[Message, Attachment, str]]
-        ] = None
-        # Total length of all songs in seconds
-        self.total_song_len: Optional[float] = None
-        # When play_next_task.cancel() is called, it is only actually cancelled on unsuspend
-        # so play_next_task.cancelled() may return False.
-        # We use this variable to keep track of /actual/ cancelled state
-        self.play_next_cancelled: Optional[bool] = False
-        # Client object
-        self.client: Client = client
+async def command_play(message: Message, skip_count: int = 0) -> None:
+    # Join active voice call
+    voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
+        message.guild.voice_channels
+    )
+    voice_channels.extend(message.guild.stage_channels)
 
-    async def stop(self) -> None:
-        """Stop playing music."""
-        self.play_next_cancelled = True
-        self.play_next_task.cancel()
-        await self.finish(say_goodbye=False)
-
-    async def play(self, message: Message, skip_count: int = 0) -> None:
-        # Join active voice call
-        voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
-            message.guild.voice_channels
+    if not voice_channels:
+        await message.channel.send(
+            "You need to be in an active voice or stage channel."
         )
-        voice_channels.extend(message.guild.stage_channels)
+        return
 
-        if not voice_channels:
-            await message.channel.send(
-                "You need to be in an active voice or stage channel."
-            )
+    # Get a reference to the bot's Member object
+    bot_member = message.guild.get_member(client.user.id)
+
+    for voice_channel in voice_channels:
+        if message.author not in voice_channel.members:
+            # Skip this voice channel
+            continue
+
+        # We found a voice channel that the author is in.
+        # Join the voice channel.
+        try:
+            global active_voice_client
+            active_voice_client = await voice_channel.connect()
+
+            # If this is a stage voice channel, ensure that we are currently speaking.
+            if voice_channel.type == ChannelType.stage_voice:
+                # Set the bot's own member to be speaking in the voice channel
+                await bot_member.edit(suppress=False)
+
+            break
+        except ClientException as e:
+            print("Unable to connect to voice channel:", e)
             return
+    else:
+        # No voice channel was found
+        await message.channel.send("You need to be in an active voice channel.")
+        return
 
-        # Get a reference to the bot's Member object
-        bot_member = message.guild.get_member(self.client.user.id)
+    # Save the bot's current display name (nick or name)
+    # We'll restore it after songs have finished playing.
+    global original_bot_nickname
+    original_bot_nickname = bot_member.display_name
 
-        for voice_channel in voice_channels:
-            if message.author not in voice_channel.members:
-                # Skip this voice channel
-                continue
+    # Play content
+    await message.channel.send("Let's get **BUSTY**.")
+    play_next_coro()
 
-            # We found a voice channel that the author is in.
-            # Join the voice channel.
-            try:
-                self.active_voice_client = await voice_channel.connect()
 
-                # If this is a stage voice channel, ensure that we are currently speaking.
-                if voice_channel.type == ChannelType.stage_voice:
-                    # Set the bot's own member to be speaking in the voice channel
-                    await bot_member.edit(suppress=False)
+def play_next_coro(skip_count: int = 0) -> None:
+    """Run play_next_song() wrapped in a coroutine so it is cancellable by stop command"""
+    global play_next_task
+    global play_next_cancelled
+    play_next_cancelled = False
+    play_next_task = client.loop.create_task(play_next_song(skip_count))
+    asyncio.run_coroutine_threadsafe(play_next_task.get_coro(), client.loop)
 
-                break
-            except ClientException as e:
-                print("Unable to connect to voice channel:", e)
-                return
-        else:
-            # No voice channel was found
-            await message.channel.send("You need to be in an active voice channel.")
-            return
 
-        # Save the bot's current display name (nick or name)
-        # We'll restore it after songs have finished playing.
-        self.original_bot_nickname = bot_member.display_name
+def command_skip() -> None:
+    # Stop any currently playing song
+    # The next song will play automatically.
+    active_voice_client.stop()
 
-        # Play content
-        await message.channel.send("Let's get **BUSTY**.")
-        self.play_next_coro()
 
-    def play_next_coro(self, skip_count: int = 0) -> None:
-        """Run play_next_song() wrapped in a coroutine so it is cancellable by stop command"""
-        self.play_next_cancelled = False
-        self.play_next_task = self.client.loop.create_task(
-            self.play_next_song(skip_count)
+async def finish_bust(say_goodbye: bool = True) -> None:
+    """End the current bust.
+
+    Args:
+        say_goodbye: If True, a goodbye message will be posted to `current_channel`. If False, the bust
+            will be ended silently.
+    """
+    global active_voice_client
+    global original_bot_nickname
+    global current_channel_content
+    global current_channel
+    global total_song_len
+
+    # Disconnect from voice if necessary
+    if active_voice_client and active_voice_client.is_connected():
+        await active_voice_client.disconnect()
+
+    # Restore the bot's original guild nickname (if it had one)
+    if original_bot_nickname and current_channel:
+        bot_member = current_channel.guild.get_member(client.user.id)
+        await bot_member.edit(nick=original_bot_nickname)
+
+    if say_goodbye:
+        embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
+        embed_content = "Hope ya had a good **BUST!**"
+        embed_content += "\n*Total length of all submissions: {}*".format(
+            song_utils.format_time(int(total_song_len))
         )
+        embed = Embed(
+            title=embed_title, description=embed_content, color=config.LIST_EMBED_COLOR
+        )
+        await current_channel.send(embed=embed)
+
+    # Clear variables relating to current bust
+    active_voice_client = None
+    original_bot_nickname = None
+    current_channel_content = None
+    current_channel = None
+    total_song_len = None
+
+
+async def play_next_song(skip_count: int = 0) -> None:
+    global current_channel_content
+    global current_channel
+    global now_playing_msg
+
+    if not current_channel_content:
+        # If there are no more songs to play, conclude the bust
+        await finish_bust()
+        return
+
+    # Wait some time between songs
+    if config.seconds_between_songs:
+        embed_title = "Currently Chilling"
+        embed_content = "Waiting for {} second{}...\n\n**REMEMBER TO VOTE ON THE GOOGLE FORM!**".format(
+            config.seconds_between_songs,
+            "s" if config.seconds_between_songs != 1 else "",
+        )
+        embed = Embed(title=embed_title, description=embed_content)
+        await current_channel.send(embed=embed)
+        await asyncio.sleep(config.seconds_between_songs)
+
+    # Remove skip_count number of songs from the front of the queue
+    current_channel_content = current_channel_content[skip_count:]
+
+    # Pop a song off the front of the queue and play it
+    (
+        submit_message,
+        attachment,
+        local_filepath,
+    ) = current_channel_content.pop(0)
+
+    # Associate a random emoji with this song
+    random_emoji = random.choice(config.emoji_list).encode("Latin1").decode()
+
+    # Build and send "Now Playing" embed
+    embed_title = f"{random_emoji} Now Playing {random_emoji}"
+    list_format = "{0}: [{1}]({2}) [`↲jump`]({3})"
+    embed_content = list_format.format(
+        submit_message.author.mention,
+        escape_markdown(song_utils.song_format(local_filepath, attachment.filename)),
+        attachment.url,
+        submit_message.jump_url,
+    )
+    embed = Embed(
+        title=embed_title, description=embed_content, color=config.PLAY_EMBED_COLOR
+    )
+
+    # Add message content as "More Info", truncating to the embed field.value character limit
+    if submit_message.content:
+        more_info = submit_message.content
+        if len(more_info) > config.EMBED_FIELD_VALUE_LIMIT:
+            more_info = more_info[: config.EMBED_FIELD_VALUE_LIMIT - 1] + "…"
+        embed.add_field(name="More Info", value=more_info, inline=False)
+
+    cover_art = song_utils.get_cover_art(local_filepath)
+    if cover_art is not None:
+        embed.set_image(url=f"attachment://{cover_art.filename}")
+        now_playing_msg = await current_channel.send(file=cover_art, embed=embed)
+    else:
+        now_playing_msg = await current_channel.send(embed=embed)
+
+    await discord_utils.try_set_pin(now_playing_msg, True)
+
+    # Called when song finishes playing
+    def ffmpeg_post_hook(e: BaseException = None):
+        global now_playing_msg
+
+        if e is not None:
+            print("Song playback quit with error:", e)
+
+        # Unpin song
         asyncio.run_coroutine_threadsafe(
-            self.play_next_task.get_coro(), self.client.loop
+            discord_utils.try_set_pin(now_playing_msg, False), client.loop
         )
+        now_playing_msg = None
 
-    def skip(self) -> None:
-        # Stop any currently playing song
-        # The next song will play automatically.
-        self.active_voice_client.stop()
+        # Play next song if we were not stopped
+        if not play_next_cancelled:
+            play_next_coro()
 
-    async def finish(self, say_goodbye: bool = True) -> None:
-        """End the current bust.
+    # Play song
+    active_voice_client.play(
+        FFmpegPCMAudio(
+            local_filepath, options=f"-filter:a volume={config.VOLUME_MULTIPLIER}"
+        ),
+        after=ffmpeg_post_hook,
+    )
 
-        Args:
-            say_goodbye: If True, a goodbye message will be posted to `current_channel`. If False, the bust
-                will be ended silently.
-        """
-        # Disconnect from voice if necessary
-        if self.active_voice_client and self.active_voice_client.is_connected():
-            await self.active_voice_client.disconnect()
+    # Change the name of the bot to that of the currently playing song.
+    # This allows people to quickly see which song is currently playing.
+    new_nick = random_emoji + song_utils.song_format(
+        local_filepath, attachment.filename, submit_message.author.display_name
+    )
 
-        # Restore the bot's original guild nickname (if it had one)
-        if self.original_bot_nickname and self.current_channel:
-            bot_member = self.current_channel.guild.get_member(self.client.user.id)
-            await bot_member.edit(nick=self.original_bot_nickname)
+    # If necessary, truncate name to 32 characters (the maximum allowed by Discord),
+    # including an ellipsis on the end.
+    if len(new_nick) > 32:
+        new_nick = new_nick[:31] + "…"
 
-        if say_goodbye:
-            embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
-            embed_content = "Hope ya had a good **BUST!**"
-            embed_content += "\n*Total length of all submissions: {}*".format(
-                song_utils.format_time(int(self.total_song_len))
-            )
-            embed = Embed(
-                title=embed_title,
-                description=embed_content,
-                color=config.LIST_EMBED_COLOR,
-            )
-            await self.current_channel.send(embed=embed)
+    # Set the new nickname
+    bot_member = current_channel.guild.get_member(client.user.id)
+    await bot_member.edit(nick=new_nick)
 
-        # Clear variables relating to current bust
-        self.active_voice_client = None
-        self.original_bot_nickname = None
-        self.current_channel_content = None
-        self.current_channel = None
-        self.total_song_len = None
 
-    async def play_next_song(self, skip_count: int = 0) -> None:
-        if not self.current_channel_content:
-            # If there are no more songs to play, conclude the bust
-            await self.finish()
+async def command_list(message: Message) -> None:
+    target_channel = message.channel
+
+    if not isinstance(target_channel, TextChannel):
+        print(f"Unsupported channel type to !list: {type(target_channel)}")
+        return
+
+    # If any channels were mentioned in the message, use the first from the list
+    if message.channel_mentions:
+        mentioned_channel = message.channel_mentions[0]
+        if isinstance(mentioned_channel, TextChannel):
+            target_channel = mentioned_channel
+        else:
+            await message.channel.send("That isn't a text channel.")
             return
+    # Scrape all tracks in the target channel and list them
+    channel_media_attachments = await discord_utils.scrape_channel_media(target_channel)
 
-        # Wait some time between songs
-        if config.seconds_between_songs:
-            embed_title = "Currently Chilling"
-            embed_content = "Waiting for {} second{}...\n\n**REMEMBER TO VOTE ON THE GOOGLE FORM!**".format(
-                config.seconds_between_songs,
-                "s" if config.seconds_between_songs != 1 else "",
-            )
-            embed = Embed(title=embed_title, description=embed_content)
-            await self.current_channel.send(embed=embed)
-            await asyncio.sleep(config.seconds_between_songs)
+    # Break on no songs to list
+    if len(channel_media_attachments) == 0:
+        await message.channel.send("There aren't any songs there.")
+        return
 
-        # Remove skip_count number of songs from the front of the queue
-        self.current_channel_content = self.current_channel_content[skip_count:]
+    # Title of !list embed
+    embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
+    embed_description_prefix = "**Track Listing**\n"
 
-        # Pop a song off the front of the queue and play it
-        (
-            submit_message,
-            attachment,
-            local_filepath,
-        ) = self.current_channel_content.pop(0)
+    # List of embed descriptions to circumvent the Discord character embed limit
+    embed_description_list: List[str] = []
+    embed_description_current = ""
 
-        # Associate a random emoji with this song
-        random_emoji = random.choice(config.emoji_list).encode("Latin1").decode()
-
-        # Build and send "Now Playing" embed
-        embed_title = f"{random_emoji} Now Playing {random_emoji}"
-        list_format = "{0}: [{1}]({2}) [`↲jump`]({3})"
-        embed_content = list_format.format(
+    for index, (
+        submit_message,
+        attachment,
+        local_filepath,
+    ) in enumerate(channel_media_attachments):
+        list_format = "**{0}.** {1}: [{2}]({3}) [`↲jump`]({4})\n"
+        song_list_entry = list_format.format(
+            index + 1,
             submit_message.author.mention,
-            escape_markdown(
-                song_utils.song_format(local_filepath, attachment.filename)
-            ),
+            song_utils.song_format(local_filepath, attachment.filename),
             attachment.url,
             submit_message.jump_url,
         )
-        embed = Embed(
-            title=embed_title, description=embed_content, color=config.PLAY_EMBED_COLOR
-        )
 
-        # Add message content as "More Info", truncating to the embed field.value character limit
-        if submit_message.content:
-            more_info = submit_message.content
-            if len(more_info) > config.EMBED_FIELD_VALUE_LIMIT:
-                more_info = more_info[: config.EMBED_FIELD_VALUE_LIMIT - 1] + "…"
-            embed.add_field(name="More Info", value=more_info, inline=False)
+        # We only add the embed description prefix to the first message
+        description_prefix_charcount = 0
+        if len(embed_description_list) == 0:
+            description_prefix_charcount = len(embed_description_prefix)
 
-        cover_art = song_utils.get_cover_art(local_filepath)
-        if cover_art is not None:
-            embed.set_image(url=f"attachment://{cover_art.filename}")
-            self.now_playing_msg = await self.current_channel.send(
-                file=cover_art, embed=embed
+        if (
+            description_prefix_charcount
+            + len(embed_description_current)
+            + len(song_list_entry)
+            > config.EMBED_DESCRIPTION_LIMIT
+        ):
+            # If adding a new list entry would go over, push our current list entries to a new embed
+            embed_description_list.append(embed_description_current)
+            # Start a new embed
+            embed_description_current = song_list_entry
+        else:
+            embed_description_current += song_list_entry
+
+    # Add the leftover part to a new embed
+    embed_description_list.append(embed_description_current)
+
+    # Iterate through each embed description, send and pin messages
+    message_list = []
+
+    # Send messages, only first message gets title and prefix
+    for index, embed_description in enumerate(embed_description_list):
+        if index == 0:
+            embed = Embed(
+                title=embed_title,
+                description=embed_description_prefix + embed_description,
+                color=config.LIST_EMBED_COLOR,
             )
         else:
-            self.now_playing_msg = await self.current_channel.send(embed=embed)
-
-        await discord_utils.try_set_pin(self.now_playing_msg, True)
-
-        # Called when song finishes playing
-        def ffmpeg_post_hook(e: BaseException = None):
-            if e is not None:
-                print("Song playback quit with error:", e)
-
-            # Unpin song
-            asyncio.run_coroutine_threadsafe(
-                discord_utils.try_set_pin(self.now_playing_msg, False), self.client.loop
+            embed = Embed(
+                description=embed_description,
+                color=config.LIST_EMBED_COLOR,
             )
-            self.now_playing_msg = None
+        list_message = await message.channel.send(embed=embed)
+        message_list.append(list_message)
 
-            # Play next song if we were not stopped
-            if not self.play_next_cancelled:
-                self.play_next_coro()
+    # If message channel == target channel, pin messages in reverse order
+    if target_channel == message.channel:
+        for list_message in reversed(message_list):
+            await discord_utils.try_set_pin(list_message, True)
 
-        # Play song
-        self.active_voice_client.play(
-            FFmpegPCMAudio(
-                local_filepath, options=f"-filter:a volume={config.VOLUME_MULTIPLIER}"
-            ),
-            after=ffmpeg_post_hook,
-        )
+    # Update global channel content
+    global current_channel_content
+    current_channel_content = channel_media_attachments
 
-        # Change the name of the bot to that of the currently playing song.
-        # This allows people to quickly see which song is currently playing.
-        new_nick = random_emoji + song_utils.song_format(
-            local_filepath, attachment.filename, submit_message.author.display_name
-        )
+    global current_channel
+    current_channel = target_channel
 
-        # If necessary, truncate name to 32 characters (the maximum allowed by Discord),
-        # including an ellipsis on the end.
-        if len(new_nick) > 32:
-            new_nick = new_nick[:31] + "…"
-
-        # Set the new nickname
-        bot_member = self.current_channel.guild.get_member(self.client.user.id)
-        await bot_member.edit(nick=new_nick)
-
-    async def list(self, message: Message) -> None:
-        target_channel = message.channel
-
-        if not isinstance(target_channel, TextChannel):
-            print(f"Unsupported channel type to !list: {type(target_channel)}")
-            return
-
-        # If any channels were mentioned in the message, use the first from the list
-        if message.channel_mentions:
-            mentioned_channel = message.channel_mentions[0]
-            if isinstance(mentioned_channel, TextChannel):
-                target_channel = mentioned_channel
-            else:
-                await message.channel.send("That isn't a text channel.")
-                return
-        # Scrape all tracks in the target channel and list them
-        channel_media_attachments = await discord_utils.scrape_channel_media(
-            target_channel
-        )
-
-        # Break on no songs to list
-        if len(channel_media_attachments) == 0:
-            await message.channel.send("There aren't any songs there.")
-            return
-
-        # Title of !list embed
-        embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
-        embed_description_prefix = "**Track Listing**\n"
-
-        # List of embed descriptions to circumvent the Discord character embed limit
-        embed_description_list: List[str] = []
-        embed_description_current = ""
-
-        for index, (
-            submit_message,
-            attachment,
-            local_filepath,
-        ) in enumerate(channel_media_attachments):
-            list_format = "**{0}.** {1}: [{2}]({3}) [`↲jump`]({4})\n"
-            song_list_entry = list_format.format(
-                index + 1,
-                submit_message.author.mention,
-                song_utils.song_format(local_filepath, attachment.filename),
-                attachment.url,
-                submit_message.jump_url,
-            )
-
-            # We only add the embed description prefix to the first message
-            description_prefix_charcount = 0
-            if len(embed_description_list) == 0:
-                description_prefix_charcount = len(embed_description_prefix)
-
-            if (
-                description_prefix_charcount
-                + len(embed_description_current)
-                + len(song_list_entry)
-                > config.EMBED_DESCRIPTION_LIMIT
-            ):
-                # If adding a new list entry would go over, push our current list entries to a new embed
-                embed_description_list.append(embed_description_current)
-                # Start a new embed
-                embed_description_current = song_list_entry
-            else:
-                embed_description_current += song_list_entry
-
-        # Add the leftover part to a new embed
-        embed_description_list.append(embed_description_current)
-
-        # Iterate through each embed description, send and pin messages
-        message_list = []
-
-        # Send messages, only first message gets title and prefix
-        for index, embed_description in enumerate(embed_description_list):
-            if index == 0:
-                embed = Embed(
-                    title=embed_title,
-                    description=embed_description_prefix + embed_description,
-                    color=config.LIST_EMBED_COLOR,
-                )
-            else:
-                embed = Embed(
-                    description=embed_description,
-                    color=config.LIST_EMBED_COLOR,
-                )
-            list_message = await message.channel.send(embed=embed)
-            message_list.append(list_message)
-
-        # If message channel == target channel, pin messages in reverse order
-        if target_channel == message.channel:
-            for list_message in reversed(message_list):
-                await discord_utils.try_set_pin(list_message, True)
-
-        # Update global channel content
-        self.current_channel_content = channel_media_attachments
-
-        self.current_channel = target_channel
-
-        # Calculate total length of all songs
-        self.total_song_len = 0
-        for _, _, local_filepath in channel_media_attachments:
-            song_len = song_utils.get_song_length(local_filepath)
-            if song_len:
-                self.total_song_len += song_len
+    # Calculate total length of all songs
+    global total_song_len
+    total_song_len = 0
+    for _, _, local_filepath in channel_media_attachments:
+        song_len = song_utils.get_song_length(local_filepath)
+        if song_len:
+            total_song_len += song_len

--- a/src/bust.py
+++ b/src/bust.py
@@ -304,6 +304,7 @@ async def create_controller(client: Client, message: Message) -> Optional[BustCo
     if message.channel_mentions:
         target_channel = message.channel_mentions[0]
 
+    # Ensure target channel is text
     if not isinstance(target_channel, TextChannel):
         print(f"Cannot create controller for {type(target_channel)}")
         await message.add_reaction(command_fail)

--- a/src/bust.py
+++ b/src/bust.py
@@ -298,7 +298,7 @@ async def create_controller(client: Client, message: Message) -> Optional[BustCo
         await message.add_reaction(command_fail)
         return None
 
-    # Ensure target channel is text
+    # Pick a text channel to run the bust in. Default to the channel the command of the command.
     target_channel = message.channel
     # If any channels were mentioned in the message, use the first from the list
     if message.channel_mentions:

--- a/src/bust.py
+++ b/src/bust.py
@@ -44,7 +44,7 @@ class BustController:
 
         # The nickname of the bot. We need to store it as it will be
         # changed while songs are being played.
-        self.original_bot_nickname: str = ""
+        self.original_bot_nickname: Optional[str] = None
 
         # The channel to send messages in
         self.current_channel: TextChannel = current_channel
@@ -182,7 +182,7 @@ class BustController:
 
         # Clear variables relating to current bust
         self.voice_client = None
-        self.original_bot_nickname = ""
+        self.original_bot_nickname = None
         self._finished = True
 
     async def play_next_song(self, skip_count: int = 0) -> None:

--- a/src/bust.py
+++ b/src/bust.py
@@ -68,7 +68,7 @@ class BustController:
 
         self._finished: bool = False
 
-    def active(self) -> bool:
+    def is_active(self) -> bool:
         return self.voice_client and self.voice_client.is_connected()
 
     def finished(self) -> bool:

--- a/src/bust.py
+++ b/src/bust.py
@@ -21,354 +21,346 @@ import config
 import discord_utils
 import song_utils
 
-# GLOBAL VARIABLES
-# The channel to send messages in
-current_channel: Optional[TextChannel] = None
-# The media in the current channel
-current_channel_content: Optional[List[Tuple[Message, Attachment, str]]] = None
-# The actively connected voice client
-active_voice_client: Optional[VoiceClient] = None
-# The nickname of the bot. We need to store it as it will be
-# changed while songs are being played.
-original_bot_nickname: Optional[str] = None
 # Allow only one async routine to calculate !list at a time
 list_task_control_lock = asyncio.Lock()
-# Total length of all songs in seconds
-total_song_len: Optional[float]
-# Currently pinned "now playing" message ID
-now_playing_msg: Optional[Message] = None
-# Keep track of the coroutine used to play the next track, which is active while
-# waiting in the intermission between songs. This task should be interrupted if
-# stopping playback is requested.
-play_next_task: Optional[asyncio.Task] = None
-# When play_next_task.cancel() is called, it is only actually cancelled on unsuspend
-# so play_next_task.cancelled() may return False.
-# We use this variable to keep track of /actual/ cancelled state
-play_next_cancelled: bool = False
-# Client object
-client: Client = None
 
 
-async def command_stop() -> None:
-    """Stop playing music."""
-    global play_next_cancelled
-    play_next_cancelled = True
-    play_next_task.cancel()
-    await finish_bust(say_goodbye=False)
+class BustController:
+    def __init__(self, client: Client):
 
+        # The actively connected voice client
+        self.active_voice_client: Optional[VoiceClient] = None
+        # The nickname of the bot. We need to store it as it will be
+        # changed while songs are being played.
+        self.original_bot_nickname: str = None
+        # Currently pinned "now playing" message ID
+        self.now_playing_msg: Optional[Message] = None
+        # Keep track of the coroutine used to play the next track, which is active while
+        # waiting in the intermission between songs. This task should be interrupted if
+        # stopping playback is requested.
+        self.play_next_task: Optional[asyncio.Task] = None
 
-async def command_play(message: Message, skip_count: int = 0) -> None:
-    # Join active voice call
-    voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
-        message.guild.voice_channels
-    )
-    voice_channels.extend(message.guild.stage_channels)
+        # The channel to send messages in
+        self.current_channel: Optional[TextChannel] = None
+        # The media in the current channel
+        self.current_channel_content: Optional[
+            List[Tuple[Message, Attachment, str]]
+        ] = None
+        # Total length of all songs in seconds
+        self.total_song_len: Optional[float] = None
+        # When play_next_task.cancel() is called, it is only actually cancelled on unsuspend
+        # so play_next_task.cancelled() may return False.
+        # We use this variable to keep track of /actual/ cancelled state
+        self.play_next_cancelled: Optional[bool] = False
+        # Client object
+        self.client: Client = client
 
-    if not voice_channels:
-        await message.channel.send(
-            "You need to be in an active voice or stage channel."
+    async def stop(self) -> None:
+        """Stop playing music."""
+        self.play_next_cancelled = True
+        self.play_next_task.cancel()
+        await self.finish(say_goodbye=False)
+
+    async def play(self, message: Message, skip_count: int = 0) -> None:
+        # Join active voice call
+        voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
+            message.guild.voice_channels
         )
-        return
+        voice_channels.extend(message.guild.stage_channels)
 
-    # Get a reference to the bot's Member object
-    bot_member = message.guild.get_member(client.user.id)
-
-    for voice_channel in voice_channels:
-        if message.author not in voice_channel.members:
-            # Skip this voice channel
-            continue
-
-        # We found a voice channel that the author is in.
-        # Join the voice channel.
-        try:
-            global active_voice_client
-            active_voice_client = await voice_channel.connect()
-
-            # If this is a stage voice channel, ensure that we are currently speaking.
-            if voice_channel.type == ChannelType.stage_voice:
-                # Set the bot's own member to be speaking in the voice channel
-                await bot_member.edit(suppress=False)
-
-            break
-        except ClientException as e:
-            print("Unable to connect to voice channel:", e)
+        if not voice_channels:
+            await message.channel.send(
+                "You need to be in an active voice or stage channel."
+            )
             return
-    else:
-        # No voice channel was found
-        await message.channel.send("You need to be in an active voice channel.")
-        return
 
-    # Save the bot's current display name (nick or name)
-    # We'll restore it after songs have finished playing.
-    global original_bot_nickname
-    original_bot_nickname = bot_member.display_name
+        # Get a reference to the bot's Member object
+        bot_member = message.guild.get_member(self.client.user.id)
 
-    # Play content
-    await message.channel.send("Let's get **BUSTY**.")
-    play_next_coro()
+        for voice_channel in voice_channels:
+            if message.author not in voice_channel.members:
+                # Skip this voice channel
+                continue
 
+            # We found a voice channel that the author is in.
+            # Join the voice channel.
+            try:
+                self.active_voice_client = await voice_channel.connect()
 
-def play_next_coro(skip_count: int = 0) -> None:
-    """Run play_next_song() wrapped in a coroutine so it is cancellable by stop command"""
-    global play_next_task
-    global play_next_cancelled
-    play_next_cancelled = False
-    play_next_task = client.loop.create_task(play_next_song(skip_count))
-    asyncio.run_coroutine_threadsafe(play_next_task.get_coro(), client.loop)
+                # If this is a stage voice channel, ensure that we are currently speaking.
+                if voice_channel.type == ChannelType.stage_voice:
+                    # Set the bot's own member to be speaking in the voice channel
+                    await bot_member.edit(suppress=False)
 
-
-def command_skip() -> None:
-    # Stop any currently playing song
-    # The next song will play automatically.
-    active_voice_client.stop()
-
-
-async def finish_bust(say_goodbye: bool = True) -> None:
-    """End the current bust.
-
-    Args:
-        say_goodbye: If True, a goodbye message will be posted to `current_channel`. If False, the bust
-            will be ended silently.
-    """
-    global active_voice_client
-    global original_bot_nickname
-    global current_channel_content
-    global current_channel
-    global total_song_len
-
-    # Disconnect from voice if necessary
-    if active_voice_client and active_voice_client.is_connected():
-        await active_voice_client.disconnect()
-
-    # Restore the bot's original guild nickname (if it had one)
-    if original_bot_nickname and current_channel:
-        bot_member = current_channel.guild.get_member(client.user.id)
-        await bot_member.edit(nick=original_bot_nickname)
-
-    if say_goodbye:
-        embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
-        embed_content = "Hope ya had a good **BUST!**"
-        embed_content += "\n*Total length of all submissions: {}*".format(
-            song_utils.format_time(int(total_song_len))
-        )
-        embed = Embed(
-            title=embed_title, description=embed_content, color=config.LIST_EMBED_COLOR
-        )
-        await current_channel.send(embed=embed)
-
-    # Clear variables relating to current bust
-    active_voice_client = None
-    original_bot_nickname = None
-    current_channel_content = None
-    current_channel = None
-    total_song_len = None
-
-
-async def play_next_song(skip_count: int = 0) -> None:
-    global current_channel_content
-    global current_channel
-    global now_playing_msg
-
-    if not current_channel_content:
-        # If there are no more songs to play, conclude the bust
-        await finish_bust()
-        return
-
-    # Wait some time between songs
-    if config.seconds_between_songs:
-        embed_title = "Currently Chilling"
-        embed_content = "Waiting for {} second{}...\n\n**REMEMBER TO VOTE ON THE GOOGLE FORM!**".format(
-            config.seconds_between_songs,
-            "s" if config.seconds_between_songs != 1 else "",
-        )
-        embed = Embed(title=embed_title, description=embed_content)
-        await current_channel.send(embed=embed)
-        await asyncio.sleep(config.seconds_between_songs)
-
-    # Remove skip_count number of songs from the front of the queue
-    current_channel_content = current_channel_content[skip_count:]
-
-    # Pop a song off the front of the queue and play it
-    (
-        submit_message,
-        attachment,
-        local_filepath,
-    ) = current_channel_content.pop(0)
-
-    # Associate a random emoji with this song
-    random_emoji = random.choice(config.emoji_list).encode("Latin1").decode()
-
-    # Build and send "Now Playing" embed
-    embed_title = f"{random_emoji} Now Playing {random_emoji}"
-    list_format = "{0}: [{1}]({2}) [`↲jump`]({3})"
-    embed_content = list_format.format(
-        submit_message.author.mention,
-        escape_markdown(song_utils.song_format(local_filepath, attachment.filename)),
-        attachment.url,
-        submit_message.jump_url,
-    )
-    embed = Embed(
-        title=embed_title, description=embed_content, color=config.PLAY_EMBED_COLOR
-    )
-
-    # Add message content as "More Info", truncating to the embed field.value character limit
-    if submit_message.content:
-        more_info = submit_message.content
-        if len(more_info) > config.EMBED_FIELD_VALUE_LIMIT:
-            more_info = more_info[: config.EMBED_FIELD_VALUE_LIMIT - 1] + "…"
-        embed.add_field(name="More Info", value=more_info, inline=False)
-
-    cover_art = song_utils.get_cover_art(local_filepath)
-    if cover_art is not None:
-        embed.set_image(url=f"attachment://{cover_art.filename}")
-        now_playing_msg = await current_channel.send(file=cover_art, embed=embed)
-    else:
-        now_playing_msg = await current_channel.send(embed=embed)
-
-    await discord_utils.try_set_pin(now_playing_msg, True)
-
-    # Called when song finishes playing
-    def ffmpeg_post_hook(e: BaseException = None):
-        global now_playing_msg
-
-        if e is not None:
-            print("Song playback quit with error:", e)
-
-        # Unpin song
-        asyncio.run_coroutine_threadsafe(
-            discord_utils.try_set_pin(now_playing_msg, False), client.loop
-        )
-        now_playing_msg = None
-
-        # Play next song if we were not stopped
-        if not play_next_cancelled:
-            play_next_coro()
-
-    # Play song
-    active_voice_client.play(
-        FFmpegPCMAudio(
-            local_filepath, options=f"-filter:a volume={config.VOLUME_MULTIPLIER}"
-        ),
-        after=ffmpeg_post_hook,
-    )
-
-    # Change the name of the bot to that of the currently playing song.
-    # This allows people to quickly see which song is currently playing.
-    new_nick = random_emoji + song_utils.song_format(
-        local_filepath, attachment.filename, submit_message.author.display_name
-    )
-
-    # If necessary, truncate name to 32 characters (the maximum allowed by Discord),
-    # including an ellipsis on the end.
-    if len(new_nick) > 32:
-        new_nick = new_nick[:31] + "…"
-
-    # Set the new nickname
-    bot_member = current_channel.guild.get_member(client.user.id)
-    await bot_member.edit(nick=new_nick)
-
-
-async def command_list(message: Message) -> None:
-    target_channel = message.channel
-
-    if not isinstance(target_channel, TextChannel):
-        print(f"Unsupported channel type to !list: {type(target_channel)}")
-        return
-
-    # If any channels were mentioned in the message, use the first from the list
-    if message.channel_mentions:
-        mentioned_channel = message.channel_mentions[0]
-        if isinstance(mentioned_channel, TextChannel):
-            target_channel = mentioned_channel
+                break
+            except ClientException as e:
+                print("Unable to connect to voice channel:", e)
+                return
         else:
-            await message.channel.send("That isn't a text channel.")
+            # No voice channel was found
+            await message.channel.send("You need to be in an active voice channel.")
             return
-    # Scrape all tracks in the target channel and list them
-    channel_media_attachments = await discord_utils.scrape_channel_media(target_channel)
 
-    # Break on no songs to list
-    if len(channel_media_attachments) == 0:
-        await message.channel.send("There aren't any songs there.")
-        return
+        # Save the bot's current display name (nick or name)
+        # We'll restore it after songs have finished playing.
+        self.original_bot_nickname = bot_member.display_name
 
-    # Title of !list embed
-    embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
-    embed_description_prefix = "**Track Listing**\n"
+        # Play content
+        await message.channel.send("Let's get **BUSTY**.")
+        self.play_next_coro()
 
-    # List of embed descriptions to circumvent the Discord character embed limit
-    embed_description_list: List[str] = []
-    embed_description_current = ""
+    def play_next_coro(self, skip_count: int = 0) -> None:
+        """Run play_next_song() wrapped in a coroutine so it is cancellable by stop command"""
+        self.play_next_cancelled = False
+        self.play_next_task = self.client.loop.create_task(
+            self.play_next_song(skip_count)
+        )
+        asyncio.run_coroutine_threadsafe(
+            self.play_next_task.get_coro(), self.client.loop
+        )
 
-    for index, (
-        submit_message,
-        attachment,
-        local_filepath,
-    ) in enumerate(channel_media_attachments):
-        list_format = "**{0}.** {1}: [{2}]({3}) [`↲jump`]({4})\n"
-        song_list_entry = list_format.format(
-            index + 1,
+    def skip(self) -> None:
+        # Stop any currently playing song
+        # The next song will play automatically.
+        self.active_voice_client.stop()
+
+    async def finish(self, say_goodbye: bool = True) -> None:
+        """End the current bust.
+
+        Args:
+            say_goodbye: If True, a goodbye message will be posted to `current_channel`. If False, the bust
+                will be ended silently.
+        """
+        # Disconnect from voice if necessary
+        if self.active_voice_client and self.active_voice_client.is_connected():
+            await self.active_voice_client.disconnect()
+
+        # Restore the bot's original guild nickname (if it had one)
+        if self.original_bot_nickname and self.current_channel:
+            bot_member = self.current_channel.guild.get_member(self.client.user.id)
+            await bot_member.edit(nick=self.original_bot_nickname)
+
+        if say_goodbye:
+            embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
+            embed_content = "Hope ya had a good **BUST!**"
+            embed_content += "\n*Total length of all submissions: {}*".format(
+                song_utils.format_time(int(self.total_song_len))
+            )
+            embed = Embed(
+                title=embed_title,
+                description=embed_content,
+                color=config.LIST_EMBED_COLOR,
+            )
+            await self.current_channel.send(embed=embed)
+
+        # Clear variables relating to current bust
+        self.active_voice_client = None
+        self.original_bot_nickname = None
+        self.current_channel_content = None
+        self.current_channel = None
+        self.total_song_len = None
+
+    async def play_next_song(self, skip_count: int = 0) -> None:
+        if not self.current_channel_content:
+            # If there are no more songs to play, conclude the bust
+            await self.finish()
+            return
+
+        # Wait some time between songs
+        if config.seconds_between_songs:
+            embed_title = "Currently Chilling"
+            embed_content = "Waiting for {} second{}...\n\n**REMEMBER TO VOTE ON THE GOOGLE FORM!**".format(
+                config.seconds_between_songs,
+                "s" if config.seconds_between_songs != 1 else "",
+            )
+            embed = Embed(title=embed_title, description=embed_content)
+            await self.current_channel.send(embed=embed)
+            await asyncio.sleep(config.seconds_between_songs)
+
+        # Remove skip_count number of songs from the front of the queue
+        self.current_channel_content = self.current_channel_content[skip_count:]
+
+        # Pop a song off the front of the queue and play it
+        (
+            submit_message,
+            attachment,
+            local_filepath,
+        ) = self.current_channel_content.pop(0)
+
+        # Associate a random emoji with this song
+        random_emoji = random.choice(config.emoji_list).encode("Latin1").decode()
+
+        # Build and send "Now Playing" embed
+        embed_title = f"{random_emoji} Now Playing {random_emoji}"
+        list_format = "{0}: [{1}]({2}) [`↲jump`]({3})"
+        embed_content = list_format.format(
             submit_message.author.mention,
-            song_utils.song_format(local_filepath, attachment.filename),
+            escape_markdown(
+                song_utils.song_format(local_filepath, attachment.filename)
+            ),
             attachment.url,
             submit_message.jump_url,
         )
+        embed = Embed(
+            title=embed_title, description=embed_content, color=config.PLAY_EMBED_COLOR
+        )
 
-        # We only add the embed description prefix to the first message
-        description_prefix_charcount = 0
-        if len(embed_description_list) == 0:
-            description_prefix_charcount = len(embed_description_prefix)
+        # Add message content as "More Info", truncating to the embed field.value character limit
+        if submit_message.content:
+            more_info = submit_message.content
+            if len(more_info) > config.EMBED_FIELD_VALUE_LIMIT:
+                more_info = more_info[: config.EMBED_FIELD_VALUE_LIMIT - 1] + "…"
+            embed.add_field(name="More Info", value=more_info, inline=False)
 
-        if (
-            description_prefix_charcount
-            + len(embed_description_current)
-            + len(song_list_entry)
-            > config.EMBED_DESCRIPTION_LIMIT
-        ):
-            # If adding a new list entry would go over, push our current list entries to a new embed
-            embed_description_list.append(embed_description_current)
-            # Start a new embed
-            embed_description_current = song_list_entry
-        else:
-            embed_description_current += song_list_entry
-
-    # Add the leftover part to a new embed
-    embed_description_list.append(embed_description_current)
-
-    # Iterate through each embed description, send and pin messages
-    message_list = []
-
-    # Send messages, only first message gets title and prefix
-    for index, embed_description in enumerate(embed_description_list):
-        if index == 0:
-            embed = Embed(
-                title=embed_title,
-                description=embed_description_prefix + embed_description,
-                color=config.LIST_EMBED_COLOR,
+        cover_art = song_utils.get_cover_art(local_filepath)
+        if cover_art is not None:
+            embed.set_image(url=f"attachment://{cover_art.filename}")
+            self.now_playing_msg = await self.current_channel.send(
+                file=cover_art, embed=embed
             )
         else:
-            embed = Embed(
-                description=embed_description,
-                color=config.LIST_EMBED_COLOR,
+            self.now_playing_msg = await self.current_channel.send(embed=embed)
+
+        await discord_utils.try_set_pin(self.now_playing_msg, True)
+
+        # Called when song finishes playing
+        def ffmpeg_post_hook(e: BaseException = None):
+            if e is not None:
+                print("Song playback quit with error:", e)
+
+            # Unpin song
+            asyncio.run_coroutine_threadsafe(
+                discord_utils.try_set_pin(self.now_playing_msg, False), self.client.loop
             )
-        list_message = await message.channel.send(embed=embed)
-        message_list.append(list_message)
+            self.now_playing_msg = None
 
-    # If message channel == target channel, pin messages in reverse order
-    if target_channel == message.channel:
-        for list_message in reversed(message_list):
-            await discord_utils.try_set_pin(list_message, True)
+            # Play next song if we were not stopped
+            if not self.play_next_cancelled:
+                self.play_next_coro()
 
-    # Update global channel content
-    global current_channel_content
-    current_channel_content = channel_media_attachments
+        # Play song
+        self.active_voice_client.play(
+            FFmpegPCMAudio(
+                local_filepath, options=f"-filter:a volume={config.VOLUME_MULTIPLIER}"
+            ),
+            after=ffmpeg_post_hook,
+        )
 
-    global current_channel
-    current_channel = target_channel
+        # Change the name of the bot to that of the currently playing song.
+        # This allows people to quickly see which song is currently playing.
+        new_nick = random_emoji + song_utils.song_format(
+            local_filepath, attachment.filename, submit_message.author.display_name
+        )
 
-    # Calculate total length of all songs
-    global total_song_len
-    total_song_len = 0
-    for _, _, local_filepath in channel_media_attachments:
-        song_len = song_utils.get_song_length(local_filepath)
-        if song_len:
-            total_song_len += song_len
+        # If necessary, truncate name to 32 characters (the maximum allowed by Discord),
+        # including an ellipsis on the end.
+        if len(new_nick) > 32:
+            new_nick = new_nick[:31] + "…"
+
+        # Set the new nickname
+        bot_member = self.current_channel.guild.get_member(self.client.user.id)
+        await bot_member.edit(nick=new_nick)
+
+    async def list(self, message: Message) -> None:
+        target_channel = message.channel
+
+        if not isinstance(target_channel, TextChannel):
+            print(f"Unsupported channel type to !list: {type(target_channel)}")
+            return
+
+        # If any channels were mentioned in the message, use the first from the list
+        if message.channel_mentions:
+            mentioned_channel = message.channel_mentions[0]
+            if isinstance(mentioned_channel, TextChannel):
+                target_channel = mentioned_channel
+            else:
+                await message.channel.send("That isn't a text channel.")
+                return
+        # Scrape all tracks in the target channel and list them
+        channel_media_attachments = await discord_utils.scrape_channel_media(
+            target_channel
+        )
+
+        # Break on no songs to list
+        if len(channel_media_attachments) == 0:
+            await message.channel.send("There aren't any songs there.")
+            return
+
+        # Title of !list embed
+        embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
+        embed_description_prefix = "**Track Listing**\n"
+
+        # List of embed descriptions to circumvent the Discord character embed limit
+        embed_description_list: List[str] = []
+        embed_description_current = ""
+
+        for index, (
+            submit_message,
+            attachment,
+            local_filepath,
+        ) in enumerate(channel_media_attachments):
+            list_format = "**{0}.** {1}: [{2}]({3}) [`↲jump`]({4})\n"
+            song_list_entry = list_format.format(
+                index + 1,
+                submit_message.author.mention,
+                song_utils.song_format(local_filepath, attachment.filename),
+                attachment.url,
+                submit_message.jump_url,
+            )
+
+            # We only add the embed description prefix to the first message
+            description_prefix_charcount = 0
+            if len(embed_description_list) == 0:
+                description_prefix_charcount = len(embed_description_prefix)
+
+            if (
+                description_prefix_charcount
+                + len(embed_description_current)
+                + len(song_list_entry)
+                > config.EMBED_DESCRIPTION_LIMIT
+            ):
+                # If adding a new list entry would go over, push our current list entries to a new embed
+                embed_description_list.append(embed_description_current)
+                # Start a new embed
+                embed_description_current = song_list_entry
+            else:
+                embed_description_current += song_list_entry
+
+        # Add the leftover part to a new embed
+        embed_description_list.append(embed_description_current)
+
+        # Iterate through each embed description, send and pin messages
+        message_list = []
+
+        # Send messages, only first message gets title and prefix
+        for index, embed_description in enumerate(embed_description_list):
+            if index == 0:
+                embed = Embed(
+                    title=embed_title,
+                    description=embed_description_prefix + embed_description,
+                    color=config.LIST_EMBED_COLOR,
+                )
+            else:
+                embed = Embed(
+                    description=embed_description,
+                    color=config.LIST_EMBED_COLOR,
+                )
+            list_message = await message.channel.send(embed=embed)
+            message_list.append(list_message)
+
+        # If message channel == target channel, pin messages in reverse order
+        if target_channel == message.channel:
+            for list_message in reversed(message_list):
+                await discord_utils.try_set_pin(list_message, True)
+
+        # Update global channel content
+        self.current_channel_content = channel_media_attachments
+
+        self.current_channel = target_channel
+
+        # Calculate total length of all songs
+        self.total_song_len = 0
+        for _, _, local_filepath in channel_media_attachments:
+            song_len = song_utils.get_song_length(local_filepath)
+            if song_len:
+                self.total_song_len += song_len

--- a/src/bust.py
+++ b/src/bust.py
@@ -21,7 +21,6 @@ import config
 import discord_utils
 import song_utils
 
-
 # Allow only one async routine to calculate !list at a time
 list_task_control_lock = asyncio.Lock()
 

--- a/src/bust.py
+++ b/src/bust.py
@@ -288,7 +288,9 @@ class BustController:
         await bot_member.edit(nick=new_nick)
 
 
-async def create_controller(client: Client, message: Message) -> Optional[BustController]:
+async def create_controller(
+    client: Client, message: Message
+) -> Optional[BustController]:
     """Attempt to create a BustController given a channel list command"""
     command_success = "\N{THUMBS UP SIGN}"
     command_fail = "\N{OCTAGONAL SIGN}"

--- a/src/bust.py
+++ b/src/bust.py
@@ -288,7 +288,7 @@ class BustController:
         await bot_member.edit(nick=new_nick)
 
 
-async def create_controller(client, message: Message) -> Optional[BustController]:
+async def create_controller(client: Client, message: Message) -> Optional[BustController]:
     """Attempt to create a BustController given a channel list command"""
     command_success = "\N{THUMBS UP SIGN}"
     command_fail = "\N{OCTAGONAL SIGN}"

--- a/src/bust.py
+++ b/src/bust.py
@@ -72,7 +72,7 @@ class BustController:
         return self.voice_client and self.voice_client.is_connected()
 
     def finished(self) -> bool:
-        # TODO: This message should become unnecessary once for-refactor is done
+        # TODO: This function should become unnecessary once for-refactor is done
         # See comment in main.py
         return self._finished
 

--- a/src/main.py
+++ b/src/main.py
@@ -118,9 +118,9 @@ async def on_message(message: Message) -> None:
         # Pull the google drive link to the form image from the message (if it exists)
         command_args = message.content.split()[1:]
         if command_args:
-            await voting.command_form(message, google_drive_image_link=command_args[0])
+            await voting.form(message, google_drive_image_link=command_args[0])
         else:
-            await voting.command_form(message)
+            await voting.form(message)
 
     elif message_text.startswith("!skip"):
         if not bust.active_voice_client or not bust.active_voice_client.is_playing():

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,13 @@
 import os
-
 from typing import Optional
+
 from nextcord import Client, Intents, Member, Message, TextChannel
 
 import bust
-from bust import BustController
 import config
-import voting
 import discord_utils
+import voting
+from bust import BustController
 
 # STARTUP
 

--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ async def on_message(message: Message) -> None:
 
     # Determine if the message was a command
     if message_text.startswith("!list"):
-        if bc and bc.active():
+        if bc and bc.is_active():
             await message.channel.send("We're busy busting.")
             return
 
@@ -86,7 +86,7 @@ async def on_message(message: Message) -> None:
         if not bc:
             await message.channel.send("You need to use !list first.")
             return
-        elif bc.active():
+        elif bc.is_active():
             await message.channel.send("We're already busting.")
             return
 
@@ -127,7 +127,7 @@ async def on_message(message: Message) -> None:
             await voting.generate_form(bc, message)
 
     elif message_text.startswith("!skip"):
-        if not bc or not bc.active():
+        if not bc or not bc.is_active():
             await message.channel.send("Nothing is playing.")
             return
 
@@ -135,7 +135,7 @@ async def on_message(message: Message) -> None:
         bc.skip_song()
 
     elif message_text.startswith("!stop"):
-        if not bc or not bc.active():
+        if not bc or not bc.is_active():
             await message.channel.send("I'm not busting.")
             return
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from nextcord import Client, Intents, Member, Message, TextChannel
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 from nextcord import Client, Intents, Member, Message, TextChannel
 
@@ -32,7 +32,7 @@ async def on_ready() -> None:
 @client.event
 async def on_close() -> None:
     # Finish all running busts on close
-    for _, bc in controllers.items():
+    for bc in controllers.values():
         await bc.finish(say_goodbye=False)
 
 
@@ -63,7 +63,7 @@ async def on_message(message: Message) -> None:
     # Allow commands to be case-sensitive and contain leading/following spaces
     message_text = message.content.lower().strip()
 
-    bc: Optional[BustController] = controllers.get(message.guild.id, None)
+    bc = controllers.get(message.guild.id, None)
     # TODO: Put these lines inside of `!bust` handler.
     # Once https://github.com/anoadragon453/busty/issues/123 is done, we can
     # keep the controllers map up to date by just deleting from

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,10 @@
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 from nextcord import Client, Intents, Member, Message, TextChannel
 
 import bust
 import config
-import discord_utils
 import voting
 from bust import BustController
 
@@ -23,7 +22,7 @@ intents.message_content = True
 # the bottom of this file.
 client = Client(intents=intents)
 
-bc: Optional[BustController] = BustController(client)
+controllers: Dict[int, BustController] = {}
 
 
 @client.event
@@ -33,15 +32,15 @@ async def on_ready() -> None:
 
 @client.event
 async def on_close() -> None:
-    # Unpin current "now playing" message if it exists
-    if bc.now_playing_msg:
-        await discord_utils.try_set_pin(bc.now_playing_msg, False)
-    # Finish current bust (if exists) as if it were stopped
-    await bc.finish(say_goodbye=False)
+    # Finish all running busts on close
+    for _, bc in controllers.items():
+        await bc.finish(say_goodbye=False)
 
 
 @client.event
 async def on_message(message: Message) -> None:
+    global controllers
+
     if message.author == client.user:
         return
 
@@ -65,31 +64,31 @@ async def on_message(message: Message) -> None:
     # Allow commands to be case-sensitive and contain leading/following spaces
     message_text = message.content.lower().strip()
 
+    bc: Optional[BustController] = controllers.get(message.guild.id, None)
+    # TODO: Put these lines inside of `!bust` handler.
+    # Once https://github.com/anoadragon453/busty/issues/123 is done, we can
+    # keep the controllers map up to date by just deleting from
+    # the controllers map directly when bc.play() returns
+    if bc and bc.finished():
+        del controllers[message.guild.id]
+        bc = None
+
     # Determine if the message was a command
     if message_text.startswith("!list"):
-        if bc.active_voice_client and bc.active_voice_client.is_connected():
+        if bc and bc.active():
             await message.channel.send("We're busy busting.")
             return
 
-        command_success = "\N{THUMBS UP SIGN}"
-        command_fail = "\N{OCTAGONAL SIGN}"
-
-        # Ensure two scrapes aren't making/deleting files at the same time
-        if bust.list_task_control_lock.locked():
-            await message.add_reaction(command_fail)
-            return
-
-        await message.add_reaction(command_success)
-        async with bust.list_task_control_lock:
-            await bc.list(message)
+        bc = await bust.create_controller(client, message)
+        if bc:
+            controllers[message.guild.id] = bc
 
     elif message_text.startswith("!bust"):
-        if bc.active_voice_client and bc.active_voice_client.is_connected():
-            await message.channel.send("We're already busting.")
-            return
-
-        if not bc.current_channel_content or not bc.current_channel:
+        if not bc:
             await message.channel.send("You need to use !list first.")
+            return
+        elif bc.active():
+            await message.channel.send("We're already busting.")
             return
 
         command_args = message.content.split()[1:]
@@ -115,19 +114,19 @@ async def on_message(message: Message) -> None:
         await bc.play(message, skip_count)
 
     elif message_text.startswith("!form"):
-        if not bc.current_channel_content or not bc.current_channel:
+        if not bc:
             await message.channel.send("You need to use !list first.")
             return
 
-        # Pull the google drive link to the form image from the message (if it exists)
+        # Pull the Google Drive link to the form image from the message (if it exists)
         command_args = message.content.split()[1:]
         if command_args:
-            await voting.form(message, google_drive_image_link=command_args[0])
+            await voting.form(bc, message, google_drive_image_link=command_args[0])
         else:
-            await voting.form(message)
+            await voting.form(bc, message)
 
     elif message_text.startswith("!skip"):
-        if not bc.active_voice_client or not bc.active_voice_client.is_playing():
+        if not bc or not bc.active():
             await message.channel.send("Nothing is playing.")
             return
 
@@ -135,7 +134,7 @@ async def on_message(message: Message) -> None:
         bc.skip()
 
     elif message_text.startswith("!stop"):
-        if not bc.active_voice_client or not bc.active_voice_client.is_connected():
+        if not bc or not bc.active():
             await message.channel.send("I'm not busting.")
             return
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,13 @@
 import os
 
+from typing import Optional
 from nextcord import Client, Intents, Member, Message, TextChannel
 
 import bust
+from bust import BustController
 import config
 import voting
+import discord_utils
 
 # STARTUP
 
@@ -19,7 +22,8 @@ intents.message_content = True
 # Set up the Discord client. Connecting to Discord is done at
 # the bottom of this file.
 client = Client(intents=intents)
-bust.client = client
+
+bc: Optional[BustController] = BustController(client)
 
 
 @client.event
@@ -30,10 +34,10 @@ async def on_ready() -> None:
 @client.event
 async def on_close() -> None:
     # Unpin current "now playing" message if it exists
-    if bust.now_playing_msg:
-        await bust.try_set_pin(bust.now_playing_msg, False)
+    if bc.now_playing_msg:
+        await discord_utils.try_set_pin(bc.now_playing_msg, False)
     # Finish current bust (if exists) as if it were stopped
-    await bust.finish_bust(say_goodbye=False)
+    await bc.finish(say_goodbye=False)
 
 
 @client.event
@@ -63,7 +67,7 @@ async def on_message(message: Message) -> None:
 
     # Determine if the message was a command
     if message_text.startswith("!list"):
-        if bust.active_voice_client and bust.active_voice_client.is_connected():
+        if bc.active_voice_client and bc.active_voice_client.is_connected():
             await message.channel.send("We're busy busting.")
             return
 
@@ -77,14 +81,14 @@ async def on_message(message: Message) -> None:
 
         await message.add_reaction(command_success)
         async with bust.list_task_control_lock:
-            await bust.command_list(message)
+            await bc.list(message)
 
     elif message_text.startswith("!bust"):
-        if bust.active_voice_client and bust.active_voice_client.is_connected():
+        if bc.active_voice_client and bc.active_voice_client.is_connected():
             await message.channel.send("We're already busting.")
             return
 
-        if not bust.current_channel_content or not bust.current_channel:
+        if not bc.current_channel_content or not bc.current_channel:
             await message.channel.send("You need to use !list first.")
             return
 
@@ -103,16 +107,16 @@ async def on_message(message: Message) -> None:
             if bust_index == 0:
                 await message.channel.send("We start from 1 around here.")
                 return
-            if bust_index > len(bust.current_channel_content):
+            if bust_index > len(bc.current_channel_content):
                 await message.channel.send("There aren't that many tracks.")
                 return
             skip_count = bust_index - 1
 
-        await bust.command_play(message, skip_count)
+        await bc.play(message, skip_count)
 
     elif message_text.startswith("!form"):
-        if not bust.current_channel_content or not bust.current_channel:
-            await message.channel.send("You need to use !list first, sugar.")
+        if not bc.current_channel_content or not bc.current_channel:
+            await message.channel.send("You need to use !list first.")
             return
 
         # Pull the google drive link to the form image from the message (if it exists)
@@ -123,20 +127,20 @@ async def on_message(message: Message) -> None:
             await voting.form(message)
 
     elif message_text.startswith("!skip"):
-        if not bust.active_voice_client or not bust.active_voice_client.is_playing():
+        if not bc.active_voice_client or not bc.active_voice_client.is_playing():
             await message.channel.send("Nothing is playing.")
             return
 
         await message.channel.send("I didn't like that track anyways.")
-        bust.command_skip()
+        bc.skip()
 
     elif message_text.startswith("!stop"):
-        if not bust.active_voice_client or not bust.active_voice_client.is_connected():
+        if not bc.active_voice_client or not bc.active_voice_client.is_connected():
             await message.channel.send("I'm not busting.")
             return
 
         await message.channel.send("Alright I'll shut up.")
-        await bust.command_stop()
+        await bc.stop()
 
 
 # Connect to Discord. YOUR_BOT_TOKEN_HERE must be replaced with

--- a/src/voting.py
+++ b/src/voting.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 from nextcord import Message
 
-from bust import BustController
 import config
 import song_utils
+from bust import BustController
 
 # TODO: Eventually the function in this file should be rewritten not interact with
 # Discord at all, and instead called by a wrapper in bust.py with most

--- a/src/voting.py
+++ b/src/voting.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from nextcord import Message
 
-import bust
+from bust import BustController
 import config
 import song_utils
 
@@ -12,13 +12,15 @@ import song_utils
 # internal logic remaining here
 
 
-async def form(message: Message, google_drive_image_link: Optional[str] = None) -> None:
+async def form(
+    bc: BustController, message: Message, google_drive_image_link: Optional[str] = None
+) -> None:
     # Escape strings so they can be assigned as literals within appscript
     def escape_appscript(text: str) -> str:
         return text.replace("\\", "\\\\").replace('"', '\\"')
 
     # Extract bust number from channel name
-    bust_number = "".join([c for c in bust.current_channel.name if c.isdigit()])
+    bust_number = "".join([c for c in bc.current_channel.name if c.isdigit()])
     if bust_number:
         bust_number = bust_number + " "
 
@@ -41,7 +43,7 @@ async def form(message: Message, google_drive_image_link: Optional[str] = None) 
                     song_utils.song_format(local_filepath, attachment.filename)
                 ),
             )
-            for submit_message, attachment, local_filepath in bust.current_channel_content
+            for submit_message, attachment, local_filepath in bc.current_channel_content
         ]
     )
     appscript += (

--- a/src/voting.py
+++ b/src/voting.py
@@ -12,9 +12,7 @@ import song_utils
 # internal logic remaining here
 
 
-async def command_form(
-    message: Message, google_drive_image_link: Optional[str] = None
-) -> None:
+async def form(message: Message, google_drive_image_link: Optional[str] = None) -> None:
     # Escape strings so they can be assigned as literals within appscript
     def escape_appscript(text: str) -> str:
         return text.replace("\\", "\\\\").replace('"', '\\"')


### PR DESCRIPTION
Taking some steps to move towards a more modular BustController. BustController should only be instantiated via a new `bust.create_controller()` method, which either constructs a valid controller or returns None. Bust state can be checked externally with the `BustController.active()` function.

Three optional variables still remain in BustController, but for now these all make sense as optional as they move in and out of existence throughout the BustController's lifecycle.

The code which calculates total song length has been moved to the BustController constructor, whereas previously it was in the list command (which has largely become the create_controller function). A few other things like whether there is an active lock are now checked within create_controller as well.

Management of active controllers is done via a map from guild id -> controller called `controllers` in `main.py`. Management is a bit suboptimal right now since we have no real way of making a "callback" when a bust finishes to remove itself from the map. This should be fixed after #123 if we write it such that `BustController.play()` is an async function which returns when the bust is over.

Despite it seeming like this setup supports multiple servers, since everything still shares an attachment folder this is untrue. It would not be too hard to have an attachment folder per-BustController in the future however.