### PR TITLE
Set doc name on form create, not form move

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -42,6 +42,7 @@ def create_remote_form(
     form_info = {
         "info": {
             "title": title,
+            "document_title": title,
         }
     }
 
@@ -136,7 +137,6 @@ def create_remote_form(
                 fileId=form_id,
                 removeParents=file_parent_id,
                 addParents=config.google_form_folder,
-                body={"name": title},
             ).execute()
         except Exception as e:
             print("Error moving form:", e)


### PR DESCRIPTION
Just small organization improvement, set document title with form title on form creation, instead of creating it with a random name and tying rename to the success or failure of the document move operation.

Not totally sure why "info.document_title" and "name" refer to the same thing, but it's what the documentation claimed, and it worked in testing.