### PR TITLE
Fix a bug where some songs would be skipped during total song length calculation

### DIFF
--- a/src/song_utils.py
+++ b/src/song_utils.py
@@ -116,7 +116,7 @@ def format_time(seconds: int) -> str:
 def get_song_length(filename: str) -> Optional[float]:
     try:
         audio = MutagenFile(filename)
-        if audio:
+        if audio is not None:
             return audio.info.length
     except MutagenError as e:
         # Ignore file and move on


### PR DESCRIPTION
Fixes https://github.com/anoadragon453/busty/issues/139

`bool(MutagenFile)` can resolve to `False` even if the file was read correctly, as `MutagenFile` inherits from [DictMixin](https://github.com/quodlibet/mutagen/blob/00aba6abfecc5353b6a51b6fa4e382ab57430b7c/mutagen/_util.py#L431-L445) (and `bool({})` resolves to `False`).

Fix the song length calculation by ensuring we check whether audio is explicitly `None`, rather than just falsey.