### PR TITLE
Make loaded image persistent across reboots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ auth/
 env/
 attachments/
 .idea/
+.image_state
 venv/
 src/__pycache__/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The complete list of environment variable configuration options is:
 1. `BUSTY_ATTACHMENT_DIR` - Directory to save attachments (default = attachments)
 1. `BUSTY_DJ_ROLE` - Name of role with permissions to run commands (default = bangermeister)
 1. `BUSTY_CUSTOM_EMOJI_FILEPATH` - The Python module to import containing the emoji list (default = emoji_list)
+1. `BUSTY_IMAGE_STATE_FILE` - The location of the file which saves the state of the currently loaded image (default = .image_state)
 
 A random emoji is displayed for each song played during a bust. The list of possible
 emoji is defined in [emoji_list.py](src/emoji_list.py). If you would like to customize

--- a/src/config.py
+++ b/src/config.py
@@ -38,6 +38,8 @@ discord_token = os.environ.get("BUSTY_DISCORD_TOKEN")
 google_form_folder = os.environ.get("BUSTY_GOOGLE_FORM_FOLDER")
 # The service account auth file to use
 google_auth_file = os.environ.get("BUSTY_GOOGLE_AUTH_FILE", "auth/service_key.json")
+# The location of the file which saves the state of the currently loaded image
+image_state_file = os.environ.get("BUSTY_IMAGE_STATE_FILE", ".image_state")
 
 # Warn about disabled Google Forms generation
 if google_form_folder is None:

--- a/src/persistent.py
+++ b/src/persistent.py
@@ -18,7 +18,7 @@ class PersistentString:
         self._value: Optional[str] = None
         # Load string if it exists
         with contextlib.suppress(FileNotFoundError):
-            with open(self.filepath) as f:
+            with open(self.filepath, "r") as f:
                 self._value = f.read()
 
     def set(self, value: Optional[str]):
@@ -26,11 +26,11 @@ class PersistentString:
 
         # Either save string, or delete state file if None
         if self._value is None:
-            with open(self.filepath, "w") as f:
-                f.write(self._value)
-        else:
             with contextlib.suppress(FileNotFoundError):
                 os.remove(self.filepath)
+        else:
+            with open(self.filepath, "w") as f:
+                f.write(self._value)
 
     def get(self) -> Optional[str]:
         return self._value

--- a/src/persistent.py
+++ b/src/persistent.py
@@ -1,0 +1,36 @@
+import contextlib
+import os
+from typing import Optional
+
+
+class PersistentString:
+    """A string wrapper which is persistent across reboots.
+
+    Methods:
+        get(value):
+            Gets the value of the string
+        set(value):
+            Sets the value of the string and writes to disk
+    """
+
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self._value: Optional[str] = None
+        # Load string if it exists
+        with contextlib.suppress(FileNotFoundError):
+            with open(self.filepath) as f:
+                self._value = f.read()
+
+    def set(self, value: Optional[str]):
+        self._value = value
+
+        # Either save string, or delete state file if None
+        if self._value is None:
+            with open(self.filepath, "w") as f:
+                f.write(self._value)
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(self.filepath)
+
+    def get(self) -> Optional[str]:
+        return self._value

--- a/src/persistent.py
+++ b/src/persistent.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 from typing import Optional
 
@@ -17,17 +16,21 @@ class PersistentString:
         self.filepath = filepath
         self._value: Optional[str] = None
         # Load string if it exists
-        with contextlib.suppress(FileNotFoundError):
+        try:
             with open(self.filepath, "r") as f:
                 self._value = f.read()
+        except FileNotFoundError:
+            pass
 
     def set(self, value: Optional[str]):
         self._value = value
 
         # Either save string, or delete state file if None
         if self._value is None:
-            with contextlib.suppress(FileNotFoundError):
+            try:
                 os.remove(self.filepath)
+            except FileNotFoundError:
+                pass
         else:
             with open(self.filepath, "w") as f:
                 f.write(self._value)

--- a/src/persistent.py
+++ b/src/persistent.py
@@ -13,7 +13,7 @@ class PersistentString:
             Sets the value of the string and writes to disk
     """
 
-    def __init__(self, filepath: str):
+    def __init__(self, filepath: str) -> None:
         self.filepath = filepath
         self._value: Optional[str] = None
         # Load string if it exists


### PR DESCRIPTION
Added a new class PersistentString, which keeps the state of an `Optional[str]` variable in a passed filepath. If the file exists when an instance is created, the string contents are loaded from file. Otherwise, they are none. Whenever the string is set, the file is either written to or deleted depending on whether the string is `None` or not.

Made `loaded_image` a PersistentString, with filepath pointed to by either env var `BUSTY_IMAGE_STATE_FILE`, or with a default value of `.image_state`.

There are a number of different ways this could have been engineered, lmk if you can think of a nicer one and we should do that. This solution seems simple and small enough that it wouldn't be too hard to replace it with something more generic and robust later if we want to start keeping other persistent data.