### PR TITLE
Send bust messages in command channel, not list channel

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -127,7 +127,7 @@ async def bust(
         )
         return
 
-    if index > len(bc.current_channel_content):
+    if index > len(bc.bust_content):
         await interaction.response.send_message(
             "There aren't that many tracks.", ephemeral=True
         )


### PR DESCRIPTION
Currently if you /bust a channel that is NOT the list channel, busty will still send messages in the listed channel. This commit changes that behavior so that the bust messages happen in the channel /bust was ran in.