### PR TITLE
Add a command which lets admins send announcements as the bot

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -258,24 +258,18 @@ async def announce(
     # Disallow sending announcements from one guild into another.
     if channel.guild.id != interaction.guild_id:
         interaction.response.send_message(
-            "Sending announcements to a guild outside of this channel is not allowed."
+            "Sending announcements to a guild outside of this channel is not allowed.",
+            ephemeral=True,
         )
         return
 
-    # If this command was invoked in the same channel the announcement is intended to be
-    # made in, then send the announcement as a response to the interaction.
+    await channel.send(embed=embed)
+    # Change reply to interaction depending on whether message was sent in current channel, or one in argument
     if channel.id == interaction.channel_id:
-        await interaction.response.send_message(embed=embed)
+        interaction_reply = "Announcement has been sent."
     else:
-        # Otherwise, we send the announcement in the separate channel...
-        await channel.send(embed=embed)
-
-        # ...and respond to the interaction with an ephemeral message informing the
-        # user that the announcement was successfully made.
-        await interaction.response.send_message(
-            f"Announcement has been sent in <#{channel.id}>.",
-            ephemeral=True,
-        )
+        interaction_reply = f"Announcement has been sent in {channel.mention}"
+    await interaction.response.send_message(interaction_reply, ephemeral=True)
 
 
 @client.event


### PR DESCRIPTION
This commit adds an `/announce` command which lets admins send an embed as the bot into any channel with a given title and body.

![image](https://user-images.githubusercontent.com/1342360/210298547-ae19dfc5-0288-4e21-97c9-6123d4bf7926.png)
![image](https://user-images.githubusercontent.com/1342360/210298525-6b372f27-a36c-42f2-996d-a32a2f037f25.png)
![image](https://user-images.githubusercontent.com/1342360/210298515-3f205185-81d8-4fb0-9ae4-a6a7618c796a.png)

You can optionally specify a channel to send the announcement in. If a channel other than the current channel is specified, then the bot will respond with an ephemeral message confirming success of the action. If the current channel is specified, then no ephemeral message will be sent (as the admin will immediately see the announcement anyways).