### PR TITLE
Handle song length errors without crashing

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -316,11 +316,18 @@ class BustController:
 
         # Compute map of submitter --> total length of all submissions
         submitter_to_len = defaultdict(lambda: 0.0)
+        # Default entry in case no valid songs w/ length
+        bot_member = interaction.guild.get_member(self.client.user.id)
+        submitter_to_len[bot_member] = 0.0
 
+        errors = False
         for submit_message, attachment, local_filepath in self.bust_content:
             song_len = song_utils.get_song_length(local_filepath)
-            submitter = submit_message.author
-            submitter_to_len[submitter] += song_len
+            if song_len:
+                submitter = submit_message.author
+                submitter_to_len[submitter] += song_len
+            else:
+                errors = True
 
         # User with longest total submission length
         longest_submitter = max(submitter_to_len, key=submitter_to_len.get)
@@ -331,11 +338,15 @@ class BustController:
                 f"*Number of tracks:* {num_songs}",
                 f"*Total track length:* {song_utils.format_time(songs_len)}",
                 f"*Total bust length:* {song_utils.format_time(bust_len)}",
-                f"*Unique submitters:* {len(submitter_to_len)}",
+                f"*Unique submitters:* {len(submitter_to_len)-1}",
                 f"*Longest submitter:* {longest_submitter.mention} - "
                 + f"{song_utils.format_time(longest_submitter_time)}",
             ]
         )
+        if errors:
+            embed_text += (
+                "\n\n**There were some errors. Statistics may not be accurate.**"
+            )
         embed = Embed(
             title="Listed Statistics",
             description=embed_text,

--- a/src/bust.py
+++ b/src/bust.py
@@ -338,6 +338,8 @@ class BustController:
                 f"*Number of tracks:* {num_songs}",
                 f"*Total track length:* {song_utils.format_time(songs_len)}",
                 f"*Total bust length:* {song_utils.format_time(bust_len)}",
+                # We account for the bot being included in the `submitter_to_len` dict
+                # by subtracting 1 from the total count.
                 f"*Unique submitters:* {len(submitter_to_len)-1}",
                 f"*Longest submitter:* {longest_submitter.mention} - "
                 + f"{song_utils.format_time(longest_submitter_time)}",


### PR DESCRIPTION
Busty crashes on `/info` if `get_song_length()` returns None (which it can). Instead, we should treat that song's length as zero and report that statistics may be inaccurate due to errors.

![image](https://user-images.githubusercontent.com/6956898/210310767-6f801d4c-c38e-4b3a-b463-9d58f645ae39.png)

To deal with the unlikely but possible case that ALL songs have errors, we introduce a "phantom submitter" which is the bot member herself, with a total submission length of zero.

![image](https://user-images.githubusercontent.com/6956898/210310947-3ff50a5e-fddc-4365-b4e5-22237c8d0bc1.png)
