### PR TITLE
Fix a missing await on `interaction.response.send_message`

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -257,7 +257,7 @@ async def announce(
 
     # Disallow sending announcements from one guild into another.
     if channel.guild.id != interaction.guild_id:
-        interaction.response.send_message(
+        await interaction.response.send_message(
             "Sending announcements to a guild outside of this channel is not allowed.",
             ephemeral=True,
         )


### PR DESCRIPTION
`interaction.response.send_message` is a Coroutine, so should be `await`d when called.

Missed in https://github.com/anoadragon453/busty/pull/153.