### PR TITLE
Don't crash when starting with no bot state file

### DIFF
--- a/src/persistent_state.py
+++ b/src/persistent_state.py
@@ -18,7 +18,7 @@ def load_state_from_disk() -> None:
         with open(bot_state_file) as f:
             bot_state_str = f.read()
     except (FileNotFoundError, IOError):
-        print(f'Could not read state from {bot_state_file}. Continuing...')
+        print(f"Could not read state from {bot_state_file}. Continuing...")
 
     if bot_state_str:
         # Load the JSON representation of the bot's state and convert it to a Python dict so

--- a/src/persistent_state.py
+++ b/src/persistent_state.py
@@ -17,8 +17,12 @@ def load_state_from_disk() -> None:
     try:
         with open(bot_state_file) as f:
             bot_state_str = f.read()
-    except (FileNotFoundError, IOError):
-        print(f"Could not read state from {bot_state_file}. Continuing...")
+    except FileNotFoundError:
+        # Expected on first run or after setting a new custom bot state filepath.
+        pass
+    except IOError:
+        print(f"Could not read state from {bot_state_file}")
+        raise
 
     if bot_state_str:
         # Load the JSON representation of the bot's state and convert it to a Python dict so

--- a/src/persistent_state.py
+++ b/src/persistent_state.py
@@ -13,13 +13,17 @@ def load_state_from_disk() -> None:
     """Read the bot state from disk and store it in memory."""
     global _bot_state
 
-    with open(bot_state_file) as f:
-        bot_state_str = f.read()
+    bot_state_str = None
+    try:
+        with open(bot_state_file) as f:
+            bot_state_str = f.read()
+    except (FileNotFoundError, IOError):
+        print(f'Could not read state from {bot_state_file}. Continuing...')
 
-        if bot_state_str:
-            # Load the JSON representation of the bot's state and convert it to a Python dict so
-            # it can be easily manipulated.
-            _bot_state = json.loads(bot_state_str)
+    if bot_state_str:
+        # Load the JSON representation of the bot's state and convert it to a Python dict so
+        # it can be easily manipulated.
+        _bot_state = json.loads(bot_state_str)
 
 
 def set_state(path: Iterable[str], value: JSON_DATA_TYPE) -> None:

--- a/src/persistent_state.py
+++ b/src/persistent_state.py
@@ -13,7 +13,6 @@ def load_state_from_disk() -> None:
     """Read the bot state from disk and store it in memory."""
     global _bot_state
 
-    bot_state_str = None
     try:
         with open(bot_state_file) as f:
             bot_state_str = f.read()


### PR DESCRIPTION
Right now if there is no bot_state.json, Busty's won't start. This is bad because the initial run will have no bot_state.json. This PR changes it so that if reading the bot_state.json file fails, a warning is printed and the bot continues with empty state.