### PR TITLE
Return Unix Timestamp inside /info embed object

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -1,5 +1,7 @@
 import asyncio
+import datetime
 import random
+import time
 from collections import defaultdict
 from typing import List, Optional, Tuple, Union
 
@@ -293,10 +295,7 @@ class BustController:
             for submit_message, attachment, local_filepath in self.bust_content
         ]
 
-        # Extract bust number from channel name
-        bust_number = "".join([c for c in self.message_channel.name if c.isdigit()])
-        if bust_number:
-            bust_number = bust_number + " "
+        bust_number = discord_utils.extract_bust_number(self.message_channel)
 
         form_url = forms.create_remote_form(
             f"Busty's {bust_number}Voting",
@@ -331,6 +330,11 @@ class BustController:
         longest_submitter = max(submitter_to_len, key=submitter_to_len.get)
         longest_submitter_time = int(submitter_to_len[longest_submitter])
 
+        # Calculate UNIX Timestamp from datetime for the End of Bust
+        unix_stamp = time.mktime(datetime.datetime.now().timetuple())
+        timestamp = str(unix_stamp).split(".")
+        unix_timestamp = f"<t:{timestamp[0]}:t>"
+
         embed_text = "\n".join(
             [
                 f"*Number of tracks:* {num_songs}",
@@ -339,6 +343,7 @@ class BustController:
                 f"*Unique submitters:* {len(submitter_to_len)}",
                 f"*Longest submitter:* {longest_submitter.mention} - "
                 + f"{song_utils.format_time(longest_submitter_time)}",
+                f"\n*End time:* {unix_timestamp}",
             ]
         )
         if errors:

--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -31,6 +31,15 @@ async def try_set_pin(message: Message, pin_state: bool) -> None:
         print("Altering message pin state failed:", e)
 
 
+def extract_bust_number(message_channel: TextChannel) -> str:
+    """Extract bust number from channel name"""
+    bust_number = "".join([c for c in message_channel.name if c.isdigit()])
+    if bust_number:
+        bust_number = bust_number + " "
+
+    return bust_number
+
+
 async def scrape_channel_media(
     channel: TextChannel,
 ) -> List[Tuple[Message, Attachment, str]]:


### PR DESCRIPTION
Closes #151.

`/info` will now return a timestamp recording the time in which the current bust ends.

Returns:
<img width="349" alt="CleanShot 2023-02-08 at 23 51 14@2x" src="https://user-images.githubusercontent.com/93141658/217678097-896698c9-a0d7-4914-b37b-9112e48f981b.png">
