### PR TITLE
Remove in-text emoji, use discord emoji format

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -165,7 +165,8 @@ class BustController:
             await bot_member.edit(nick=self.original_bot_nickname)
 
         if say_goodbye:
-            embed_title = "❤️‍🔥 That's it everyone ❤️‍🔥"
+            goodbye_emoji = ":heart_on_fire:"
+            embed_title = f"{goodbye_emoji} That's it everyone {goodbye_emoji}"
             embed_content = "Hope ya had a good **BUST!**"
             embed_content += "\n*Total length of all submissions: {}*".format(
                 song_utils.format_time(int(self.total_song_len))
@@ -364,14 +365,15 @@ async def create_controller(
     channel_media_attachments = await discord_utils.scrape_channel_media(list_channel)
     if not channel_media_attachments:
         await interaction.edit_original_message(
-            content="\N{WARNING SIGN} No valid media files found."
+            content=":warning: No valid media files found."
         )
         return None
 
     bc = BustController(client, channel_media_attachments, interaction.channel)
 
     # Title of /list embed
-    embed_title = "❤️‍🔥 AIGHT. IT'S BUSTY TIME ❤️‍🔥"
+    bust_emoji = ":heart_on_fire:"
+    embed_title = f"{bust_emoji} AIGHT. IT'S BUSTY TIME {bust_emoji}"
     embed_description_prefix = "**Track Listing**\n"
 
     # List of embed descriptions to circumvent the Discord character embed limit
@@ -447,7 +449,7 @@ async def create_controller(
             print("Unknown error generating form:", e)
 
         if form_url is not None:
-            vote_emoji = "\N{BALLOT BOX WITH BALLOT}"
+            vote_emoji = ":ballot_box_with_ballot:"
             form_message = await interaction.channel.send(
                 f"{vote_emoji} **Voting Form** {vote_emoji}\n{form_url}"
             )

--- a/src/main.py
+++ b/src/main.py
@@ -177,7 +177,7 @@ async def image_upload(interaction: Interaction, image_file: Attachment) -> None
         return
 
     await interaction.response.send_message(
-        f"\N{WHITE HEAVY CHECK MARK} Image set to {image_file.url}."
+        f":white_check_mark: Image set to {image_file.url}."
     )
 
 
@@ -191,7 +191,7 @@ async def image_by_url(interaction: Interaction, image_url: str) -> None:
         return
 
     await interaction.response.send_message(
-        f"\N{WHITE HEAVY CHECK MARK} Image set to {image_url}."
+        f":white_check_mark: Image set to {image_url}."
     )
 
 
@@ -204,7 +204,7 @@ async def image_clear(interaction: Interaction) -> None:
         await interaction.response.send_message("No image is loaded.", ephemeral=True)
         return
 
-    await interaction.response.send_message("\N{WASTEBASKET} Image cleared.")
+    await interaction.response.send_message(":wastebasket: Image cleared.")
 
 
 @image.subcommand(name="view")


### PR DESCRIPTION
Just some nice cleanup, we use discord emoji format in emoji_list.py and it was a bit ugly having in-text emoji mixed into an otherwise ascii codebase