### PR TITLE
Defer potentially long commands

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -85,6 +85,7 @@ class BustController:
             self.play_song_task.cancel()
 
     async def play(self, interaction: Interaction, skip_count: int = 0) -> None:
+        await interaction.response.defer(ephemeral=True)
         # Join active voice call
         voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
             interaction.guild.voice_channels
@@ -131,6 +132,7 @@ class BustController:
         self.original_bot_nickname = bot_member.display_name
 
         await interaction.channel.send("Let's get **BUSTY**.")
+        interaction.delete_original_message()
 
         # Play songs
         for index in range(skip_count, len(self.bust_content)):
@@ -311,6 +313,7 @@ class BustController:
         return form_url
 
     async def send_stats(self, interaction: Interaction) -> None:
+        interaction.defer(ephemeral=True)
         songs_len = int(self.total_song_len)
         num_songs = len(self.bust_content)
         bust_len = songs_len + config.seconds_between_songs * num_songs
@@ -360,6 +363,7 @@ async def create_controller(
     list_channel: TextChannel,
 ) -> Optional[BustController]:
     """Attempt to create a BustController given a channel list command"""
+    await interaction.response.defer(ephemeral=True)
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await discord_utils.scrape_channel_media(list_channel)
     if not channel_media_attachments:
@@ -453,5 +457,6 @@ async def create_controller(
             )
             await discord_utils.try_set_pin(form_message, True)
 
+    await interaction.delete_original_message()
     # Return controller
     return bc

--- a/src/bust.py
+++ b/src/bust.py
@@ -93,7 +93,7 @@ class BustController:
         voice_channels.extend(interaction.guild.stage_channels)
 
         if not voice_channels:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "You need to be in an active voice or stage channel.", ephemeral=True
             )
             return
@@ -122,7 +122,7 @@ class BustController:
                 return
         else:
             # No voice channel was found
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "You need to be in an active voice channel.", ephemeral=True
             )
             return
@@ -313,7 +313,7 @@ class BustController:
         return form_url
 
     async def send_stats(self, interaction: Interaction) -> None:
-        await interaction.defer(ephemeral=True)
+        await interaction.response.defer(ephemeral=True)
         songs_len = int(self.total_song_len)
         num_songs = len(self.bust_content)
         bust_len = songs_len + config.seconds_between_songs * num_songs
@@ -354,7 +354,7 @@ class BustController:
             description=embed_text,
             color=config.INFO_EMBED_COLOR,
         )
-        await interaction.response.send_message(embed=embed)
+        await interaction.followup.send(embed=embed)
 
 
 async def create_controller(

--- a/src/bust.py
+++ b/src/bust.py
@@ -132,7 +132,7 @@ class BustController:
         self.original_bot_nickname = bot_member.display_name
 
         await interaction.channel.send("Let's get **BUSTY**.")
-        interaction.delete_original_message()
+        await interaction.delete_original_message()
 
         # Play songs
         for index in range(skip_count, len(self.bust_content)):
@@ -313,7 +313,7 @@ class BustController:
         return form_url
 
     async def send_stats(self, interaction: Interaction) -> None:
-        interaction.defer(ephemeral=True)
+        await interaction.defer(ephemeral=True)
         songs_len = int(self.total_song_len)
         num_songs = len(self.bust_content)
         bust_len = songs_len + config.seconds_between_songs * num_songs

--- a/src/bust.py
+++ b/src/bust.py
@@ -33,7 +33,6 @@ class BustController:
         bust_content: List[Tuple[Message, Attachment, str]],
         message_channel: TextChannel,
     ):
-
         # The actively connected voice client
         self.voice_client: Optional[VoiceClient] = None
         # Currently pinned "now playing" message ID
@@ -85,6 +84,13 @@ class BustController:
             self.play_song_task.cancel()
 
     async def play(self, interaction: Interaction, skip_count: int = 0) -> None:
+        """Begin playback.
+
+        Args:
+            interaction: An interaction which has not yet been responded to.
+            skip_count: List index to start playback from.
+        """
+
         await interaction.response.defer(ephemeral=True)
         # Join active voice call
         voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
@@ -314,6 +320,10 @@ class BustController:
         return form_url
 
     async def send_stats(self, interaction: Interaction) -> None:
+        """Send statistics about current bust.
+
+        Args:
+            interaction: An interaction which has not yet been responded to."""
         await interaction.response.defer(ephemeral=True)
         songs_len = int(self.total_song_len)
         num_songs = len(self.bust_content)
@@ -363,7 +373,11 @@ async def create_controller(
     interaction: Interaction,
     list_channel: TextChannel,
 ) -> Optional[BustController]:
-    """Attempt to create a BustController given a channel list command"""
+    """Attempt to create a BustController listing a given channel.
+
+    Args:
+        interaction: An interaction which has not yet been responded to
+    """
     await interaction.response.defer(ephemeral=True)
     # Scrape all tracks in the target channel and list them
     channel_media_attachments = await discord_utils.scrape_channel_media(list_channel)

--- a/src/forms.py
+++ b/src/forms.py
@@ -38,7 +38,6 @@ def create_remote_form(
     high_label: str,
     image_url: Optional[str] = None,
 ) -> Optional[str]:
-
     form_info = {
         "info": {
             "title": title,

--- a/src/main.py
+++ b/src/main.py
@@ -83,7 +83,6 @@ async def on_list(
         list_channel = interaction.channel
 
     async with list_task_control_lock:
-        # Notify user that "Busty is thinking"
         bc = await create_controller(client, interaction, list_channel)
         global controllers
         controllers[interaction.guild_id] = bc

--- a/src/main.py
+++ b/src/main.py
@@ -243,7 +243,7 @@ async def announce(
     ),
 ) -> None:
     """Send a message as the bot into a channel wrapped in an embed."""
-    interaction.defer(ephemeral=True)
+    await interaction.defer(ephemeral=True)
     if channel is None:
         # Default to the current channel that the command was invoked in.
         channel = interaction.channel

--- a/src/main.py
+++ b/src/main.py
@@ -243,7 +243,7 @@ async def announce(
     ),
 ) -> None:
     """Send a message as the bot into a channel wrapped in an embed."""
-    await interaction.defer(ephemeral=True)
+    await interaction.response.defer(ephemeral=True)
     if channel is None:
         # Default to the current channel that the command was invoked in.
         channel = interaction.channel
@@ -257,7 +257,7 @@ async def announce(
 
     # Disallow sending announcements from one guild into another.
     if channel.guild.id != interaction.guild_id:
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "Sending announcements to a guild outside of this channel is not allowed.",
             ephemeral=True,
         )
@@ -269,7 +269,7 @@ async def announce(
         interaction_reply = "Announcement has been sent."
     else:
         interaction_reply = f"Announcement has been sent in {channel.mention}."
-    await interaction.response.send_message(interaction_reply, ephemeral=True)
+    await interaction.followup.send(interaction_reply, ephemeral=True)
 
 
 @client.event

--- a/src/main.py
+++ b/src/main.py
@@ -84,14 +84,9 @@ async def on_list(
 
     async with list_task_control_lock:
         # Notify user that "Busty is thinking"
-        await interaction.response.defer(ephemeral=True)
         bc = await create_controller(client, interaction, list_channel)
         global controllers
         controllers[interaction.guild_id] = bc
-        # If bc is None, something went wrong and we already edited the
-        # interaction response to inform the user.
-        if bc is not None:
-            await interaction.delete_original_message()
 
 
 # Bust command
@@ -248,6 +243,7 @@ async def announce(
     ),
 ) -> None:
     """Send a message as the bot into a channel wrapped in an embed."""
+    interaction.defer(ephemeral=True)
     if channel is None:
         # Default to the current channel that the command was invoked in.
         channel = interaction.channel


### PR DESCRIPTION
Closes #171.  Any commands which could potentially take a long time* are now deferred. Also, I've refactored so that when an interaction is passed to a bust controller function it can be assumed to be handled "within" and that bust controller function never returns with an non-replied-to interaction. Defer, error-handling, and "OK" interaction replies are now in the bust controller.

* Technically when saving persistent states file write could take a very long time, but I didn't defer those. Also I guess your CPU clock could be reeeeeally slow....

When using `interaction.response.defer()` your one initial interaction allowance is spent, so you have to use `interaction.followup.send` instead of `interaction.response.send()` afterwards.