### PR TITLE
Add multiserver support

### DIFF
--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -31,20 +31,18 @@ async def try_set_pin(message: Message, pin_state: bool) -> None:
         print("Altering message pin state failed:", e)
 
 
-def build_filepath_for_attachment(message_id: int, attachment: Attachment) -> str:
+def build_filepath_for_attachment(guild_id: int, attachment: Attachment) -> str:
     """Generate a unique, absolute filepath for a given attachment located in the configured attachment directory."""
 
     # Generate and return a filepath in the following format:
-    #     <attachment_directory>/<Discord message ID>.<attachment ID>.<file extension>
+    #     <attachment_directory>/<Discord guild ID>/<attachment ID>.<file extension>
     # For example:
-    #     /home/user/busty/625891304148303894.625891304081063986.mp3
-
-    # The Discord Message ID is included as well, as individual messages can have multiple attachments.
+    #     /home/user/busty/attachments/922994022916698154/625891304081063986.mp3
 
     filepath = path.join(
         config.attachment_directory_filepath,
-        "{}.{}{}".format(
-            message_id,
+        str(guild_id),
+        "{}{}".format(
             attachment.id,
             os.path.splitext(attachment.filename)[1],
         ),
@@ -66,9 +64,13 @@ async def scrape_channel_media(
     # A list of (original message, message attachment, local filepath)
     channel_media_attachments: List[Tuple[Message, Attachment, str]] = []
 
+    attachment_dir = path.join(
+        config.attachment_directory_filepath, str(channel.guild.id)
+    )
+
     # Ensure attachment directory exists
-    if not os.path.exists(config.attachment_directory_filepath):
-        os.mkdir(config.attachment_directory_filepath)
+    if not os.path.exists(attachment_dir):
+        os.makedirs(attachment_dir)
 
     # Iterate through each message in the channel
     async for message in channel.history(
@@ -83,7 +85,9 @@ async def scrape_channel_media(
                 # Ignore non-audio/video attachments
                 continue
 
-            attachment_filepath = build_filepath_for_attachment(message.id, attachment)
+            attachment_filepath = build_filepath_for_attachment(
+                channel.guild.id, attachment
+            )
 
             channel_media_attachments.append(
                 (
@@ -93,6 +97,15 @@ async def scrape_channel_media(
                 )
             )
 
+    # Clear unused files in attachment directory
+    used_files = {path for (_, _, path) in channel_media_attachments}
+    for filename in os.listdir(attachment_dir):
+        filepath = path.join(attachment_dir, filename)
+        if filepath not in used_files:
+            if os.path.isfile(filepath):
+                os.remove(filepath)
+
+    # Download attachments
     download_semaphore = asyncio.Semaphore(value=config.MAXIMUM_CONCURRENT_DOWNLOADS)
 
     # Save all files if not in cache
@@ -110,13 +123,5 @@ async def scrape_channel_media(
             for _, at, fp in channel_media_attachments
         ]
         await asyncio.wait(tasks)
-
-    # Clear unused files in attachment directory
-    used_files = {path for (_, _, path) in channel_media_attachments}
-    for filename in os.listdir(config.attachment_directory_filepath):
-        filepath = path.join(config.attachment_directory_filepath, filename)
-        if filepath not in used_files:
-            if os.path.isfile(filepath):
-                os.remove(filepath)
 
     return channel_media_attachments

--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -97,7 +97,7 @@ async def scrape_channel_media(
                 )
             )
 
-    # Clear unused files in attachment directory
+    # Clear unused files in this guild's attachment directory
     used_files = {path for (_, _, path) in channel_media_attachments}
     for filename in os.listdir(attachment_dir):
         filepath = path.join(attachment_dir, filename)

--- a/src/main.py
+++ b/src/main.py
@@ -58,7 +58,6 @@ async def on_list(
     ),
 ) -> None:
     """Download and list all media sent in a chosen text channel."""
-    global controllers
     bc = controllers.get(interaction.guild_id)
 
     if bc and bc.is_active():
@@ -93,7 +92,6 @@ async def bust(
     ),
 ) -> None:
     """Begin a bust."""
-    global controllers
     bc = controllers.get(interaction.guild_id)
 
     if bc is None:
@@ -122,7 +120,6 @@ async def bust(
 @application_checks.has_role(config.dj_role_name)
 async def skip(interaction: Interaction) -> None:
     """Skip currently playing song."""
-    global controllers
     bc = controllers.get(interaction.guild_id)
 
     if not bc or not bc.is_active():
@@ -138,7 +135,6 @@ async def skip(interaction: Interaction) -> None:
 @application_checks.has_role(config.dj_role_name)
 async def stop(interaction: Interaction) -> None:
     """Stop playback."""
-    global controllers
     bc = controllers.get(interaction.guild_id)
 
     if not bc or not bc.is_active():
@@ -216,7 +212,6 @@ async def image_view(interaction: Interaction) -> None:
 @application_checks.has_role(config.dj_role_name)
 async def info(interaction: Interaction) -> None:
     """Get info about currently listed songs."""
-    global controllers
     bc = controllers.get(interaction.guild_id)
 
     if bc is None:


### PR DESCRIPTION
Closes #148.

The main changes are
1) Turn attachments directory format in `build_filepath_for_attachment()` from `<attachment_dir>/<message_id>.<attachment_id>.<extension>` to `<attachment_dir>/<guild_id>/<attachment_id>.<extension>`.
2) Move clearing useless cached files above the code for downloading new files, to save on disk space
3) In `main.py`, remove the `get_controller()` method, which was a hack since we could not previously have a BustController remove itself from the guild_id --> BustController map after busting. Now that BustController.play() returns only after the bust is complete we can do it ourselves.

Thankfully the persistent_state module was written with multiserver in mind, so no changes needed to be made there. This has all been tested to the best of my abilities.