### PR TITLE
Fix issues with Mutagen file detection

### DIFF
--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -35,17 +35,12 @@ def build_filepath_for_attachment(guild_id: int, attachment: Attachment) -> str:
     """Generate a unique, absolute filepath for a given attachment located in the configured attachment directory."""
 
     # Generate and return a filepath in the following format:
-    #     <attachment_directory>/<Discord guild ID>/<attachment ID>.<file extension>
+    #     <attachment_directory>/<Discord guild ID>/<attachment ID>
     # For example:
-    #     /home/user/busty/attachments/922994022916698154/625891304081063986.mp3
+    #     /home/user/busty/attachments/922994022916698154/625891304081063986
 
     filepath = path.join(
-        config.attachment_directory_filepath,
-        str(guild_id),
-        "{}{}".format(
-            attachment.id,
-            os.path.splitext(attachment.filename)[1],
-        ),
+        config.attachment_directory_filepath, str(guild_id), f"{attachment.id}"
     )
     return filepath
 

--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -40,7 +40,7 @@ def build_filepath_for_attachment(guild_id: int, attachment: Attachment) -> str:
     #     /home/user/busty/attachments/922994022916698154/625891304081063986
 
     return path.join(
-        config.attachment_directory_filepath, str(guild_id), f"{attachment.id}"
+        config.attachment_directory_filepath, str(guild_id), str(attachment.id)
     )
 
 

--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -39,10 +39,9 @@ def build_filepath_for_attachment(guild_id: int, attachment: Attachment) -> str:
     # For example:
     #     /home/user/busty/attachments/922994022916698154/625891304081063986
 
-    filepath = path.join(
+    return path.join(
         config.attachment_directory_filepath, str(guild_id), f"{attachment.id}"
     )
-    return filepath
 
 
 def is_valid_media(attachment_content_type: Optional[str]) -> bool:

--- a/src/song_utils.py
+++ b/src/song_utils.py
@@ -1,6 +1,6 @@
 import base64
 from io import BytesIO
-from os import path
+import os
 from typing import Optional
 
 from mutagen import File as MutagenFile, MutagenError
@@ -100,7 +100,7 @@ def song_format(
     if title:
         content += title
     else:
-        filename = path.splitext(filename)[0]
+        filename = os.path.splitext(filename)[0]
         content += filename.replace("_", " ")
 
     return content
@@ -152,7 +152,6 @@ def get_song_length(filename: str) -> Optional[float]:
         if audio is not None:
             return audio.info.length
     except MutagenError as e:
-        # Ignore file and move on
         print(f"Error reading length of {filename}:", e)
     except Exception as e:
         print(f"Unknown error reading length of {filename}:", e)

--- a/src/song_utils.py
+++ b/src/song_utils.py
@@ -1,6 +1,6 @@
 import base64
-from io import BytesIO
 import os
+from io import BytesIO
 from typing import Optional
 
 from mutagen import File as MutagenFile, MutagenError


### PR DESCRIPTION
Closes #162, where Mutagen overweights file extension in guessing filetypes. With this we can finally retire the `ugly_info_fix` branch.

There are basically three solutions to this problem that I can think of.

1. Solve the problem upstream in Mutagen. The most morally righteous, but would may require navigating some pushback and take time to get merged and released
2. Detect better file extension (with magic/guessing/using default ext with no hints), symlink using that extension, and pass the symlink to mutagen. Variants for doing this every time, only if reading fails, etc etc. All of these are a little ugly and hacky in my opinion.
3. ⭐ What this PR does, remove file extensions when we save attachments in the first place. FFMPEG should have no issue determining file formats without an extension and Mutagen seems not to either in my testing, though if this is merged it would be good to test all past busts to be sure.

IMO 3 is the best solution because it seems like something we could have reasonably done intentionally as a design decision in the first place instead of to circumvent a bug. Let me know your thoughts.

This PR also contains very minor formatting changes in `song_utils.py` that don't change any logic, just 'cause.