### PR TITLE
Return the "edit" URL for google forms to work around #179

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -141,4 +141,6 @@ def create_remote_form(
         except Exception as e:
             print("Error moving form:", e)
 
-    return form_url
+    #return form_url
+    # Temporary patch to work around https://github.com/anoadragon453/busty/issues/179
+    return f"https://docs.google.com/forms/d/{form_id}/edit"


### PR DESCRIPTION
A temporary patch to work around https://github.com/anoadragon453/busty/issues/179. This implements the solution posited at the end of the issue:

> Instead, to work around this (temporary?) problem, we can just give everyone the /edit URL. Regular users will be directed to a sign-in page initially until an admin clicks that URL. Once they do, regular users will get the form as before (with a request edit access button in the corner, but that's fine).

**This PR should not be merged as-is.**