### PR TITLE
Make OpenAI model configurable via environ variables

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -29,8 +29,6 @@ VOLUME_MULTIPLIER = 0.5
 MAXIMUM_CONCURRENT_DOWNLOADS = 8
 # The URL that the '↲jump' link will lead to when using the /preview command.
 PREVIEW_JUMP_URL = "https://youtu.be/J45GvH2_Ato"
-# The OpenAI model to use for GPT abilities
-OPENAI_MODEL = "gpt-3.5-turbo"
 
 # SETTINGS
 # How many seconds to wait in-between songs
@@ -53,6 +51,8 @@ llm_context_file = os.environ.get("BUSTY_LLM_CONTEXT_FILE", "llm_context.json")
 testing_guild = os.environ.get("BUSTY_TESTING_GUILD_ID", None)
 # OpenAI API Key
 openai_api_key = os.environ.get("BUSTY_OPENAI_API_KEY", None)
+# The OpenAI model to use for GPT abilities
+openai_model= os.environ.get("BUSTY_OPENAI_MODEL", "gpt-3.5-turbo")
 
 # TYPES
 # Acceptable data types to store in a JSON representation.

--- a/src/config.py
+++ b/src/config.py
@@ -52,7 +52,7 @@ testing_guild = os.environ.get("BUSTY_TESTING_GUILD_ID", None)
 # OpenAI API Key
 openai_api_key = os.environ.get("BUSTY_OPENAI_API_KEY", None)
 # The OpenAI model to use for GPT abilities
-openai_model= os.environ.get("BUSTY_OPENAI_MODEL", "gpt-3.5-turbo")
+openai_model = os.environ.get("BUSTY_OPENAI_MODEL", "gpt-3.5-turbo")
 
 # TYPES
 # Acceptable data types to store in a JSON representation.

--- a/src/llm.py
+++ b/src/llm.py
@@ -38,7 +38,7 @@ def initialize(client: Client) -> None:
         context_data = None
         return
     # Preload tokenizer
-    encoding = tiktoken.encoding_for_model(config.OPENAI_MODEL)
+    encoding = tiktoken.encoding_for_model(config.openai_model)
     # Store bot user
     self_user = client.user
     # Cache regex for banned words
@@ -233,7 +233,7 @@ async def get_message_context(message: Message) -> List[str]:
 async def query_api(data: Dict) -> Optional[str]:
     try:
         response = await openai.ChatCompletion.acreate(
-            model=config.OPENAI_MODEL,
+            model=config.openai_model,
             messages=data,
             timeout=10.0,
         )


### PR DESCRIPTION
OpenAI updates models by first allowing you to to upgrade manually, then eventually upgrading the pointer from the stable version. Because of this it would be nice to be able to keep the stable version as the default value, but allow environ variable configurability for easy upgrade. See screenshot from OpenAI new model announcement email below
![image](https://github.com/anoadragon453/busty/assets/6956898/77d6699f-254c-4434-8f2f-b5970581e44e)
