### PR TITLE
Switch message channel to where bust command is issued from

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -97,6 +97,7 @@ class BustController:
         """
 
         await interaction.response.defer(ephemeral=True)
+
         # Update message channel to where command was issued from
         self.message_channel = interaction.channel
 

--- a/src/bust.py
+++ b/src/bust.py
@@ -97,6 +97,9 @@ class BustController:
         """
 
         await interaction.response.defer(ephemeral=True)
+        # Update message channel to where command was issued from
+        self.message_channel = interaction.channel
+
         # Join active voice call
         voice_channels: List[Union[VoiceChannel, StageChannel]] = list(
             interaction.guild.voice_channels
@@ -142,7 +145,7 @@ class BustController:
         # We'll restore it after songs have finished playing.
         self.original_bot_nickname = bot_member.display_name
 
-        await interaction.channel.send("Let's get **BUSTY**.")
+        await self.message_channel.send("Let's get **BUSTY**.")
         await interaction.delete_original_message()
 
         # Play songs

--- a/src/bust.py
+++ b/src/bust.py
@@ -99,6 +99,7 @@ class BustController:
         await interaction.response.defer(ephemeral=True)
 
         # Update message channel to where command was issued from
+        # (in case `list` was called from a separate/private channel).
         self.message_channel = interaction.channel
 
         # Join active voice call


### PR DESCRIPTION
We recently had an issue where Busty crashed mid-bust. This doesn't fix that, but it does fix another issue we found afterwards where if we listed from another channel (bod dev channel), it would continue to send messages from the channel we listed from, even if /bust was issued elsewhere (the mailbox).

This PR makes it so that the message channel (where messages are sent) gets updated whenever /list OR /bust is run.