### PR TITLE
Change mutagen dependency to git version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord_emoji>=1.4.1
-mutagen>=1.45.1
+git+https://github.com/quodlibet/mutagen.git
 nextcord[voice]>=2.4.1
 google-api-python-client>=2.57.0
 oauth2client>=4.1.3


### PR DESCRIPTION
We rely on https://github.com/quodlibet/mutagen/pull/601 to be able to detect song lengths for tagless mp3s. However this is not in a current release of Mutagen. The last release of Mutagen was Oct 2022 and a new release seems stalled https://github.com/quodlibet/mutagen/pull/612.

I updated venv packages at some point and reintroduced this "bug" by accident, so I think it's good that `requirements.txt` reflect the real expected requirements. We could additionally choose to pin a specific commit after testing.