### PR TITLE
Add replay command

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -160,7 +160,9 @@ class BustController:
                 break
 
             # wrap play_song() in a coroutine so it is cancellable
-            self.play_song_task = asyncio.create_task(self.play_song(self.playing_index))
+            self.play_song_task = asyncio.create_task(
+                self.play_song(self.playing_index)
+            )
             try:
                 await self.play_song_task
             except asyncio.CancelledError:

--- a/src/bust.py
+++ b/src/bust.py
@@ -65,7 +65,7 @@ class BustController:
         self.now_playing_str = None
 
         self._finished: bool = False
-        self.playing_index: Optional[bool] = None
+        self._playing_index: Optional[int] = None
 
     def is_active(self) -> bool:
         return self.voice_client and self.voice_client.is_connected()

--- a/src/bust.py
+++ b/src/bust.py
@@ -84,7 +84,7 @@ class BustController:
         if self.play_song_task:
             self.play_song_task.cancel()
 
-    def skip_to_track(self, track_number) -> None:
+    def skip_to_track(self, track_number: int) -> None:
         """Skip to track number (0-indexed)."""
         if self.play_song_task:
             # Reduce playing index so it stays the same after increment upon task cancel

--- a/src/bust.py
+++ b/src/bust.py
@@ -65,6 +65,7 @@ class BustController:
         self.now_playing_str = None
 
         self._finished: bool = False
+        self.playing_index: Optional[bool] = None
 
     def is_active(self) -> bool:
         return self.voice_client and self.voice_client.is_connected()
@@ -77,15 +78,17 @@ class BustController:
         # See comment in main.py
         return self._finished
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """Stop playing music."""
         self.bust_stopped = True
         if self.play_song_task:
             self.play_song_task.cancel()
 
-    def skip_song(self) -> None:
-        """Skip current track."""
+    def skip_to_track(self, track_number) -> None:
+        """Skip to track number (0-indexed)."""
         if self.play_song_task:
+            # Reduce playing index so it stays the same after increment upon task cancel
+            self.playing_index = max(0, track_number) - 1
             self.play_song_task.cancel()
 
     async def play(self, interaction: Interaction, skip_count: int = 0) -> None:
@@ -151,17 +154,20 @@ class BustController:
         await interaction.delete_original_message()
 
         # Play songs
-        for index in range(skip_count, len(self.bust_content)):
+        self.playing_index = skip_count
+        while self.playing_index < len(self.bust_content):
             if self.bust_stopped:
                 break
 
             # wrap play_song() in a coroutine so it is cancellable
-            self.play_song_task = asyncio.create_task(self.play_song(index))
+            self.play_song_task = asyncio.create_task(self.play_song(self.playing_index))
             try:
                 await self.play_song_task
             except asyncio.CancelledError:
                 # Voice client playback must be manually stopped
                 self.voice_client.stop()
+
+            self.playing_index += 1
 
         # tidy up
         await self.finish(say_goodbye=not self.bust_stopped)
@@ -173,6 +179,8 @@ class BustController:
             say_goodbye: If True, a goodbye message will be posted to `message_channel`. If False, the bust
                 will be ended silently.
         """
+        self.playing_index = None
+
         # Disconnect from voice if necessary
         if self.voice_client and self.voice_client.is_connected():
             await self.voice_client.disconnect()

--- a/src/main.py
+++ b/src/main.py
@@ -147,7 +147,22 @@ async def skip(interaction: Interaction) -> None:
         return
 
     await interaction.send("I didn't like that track anyways.")
-    bc.skip_song()
+    bc.skip_to_track(bc.playing_index + 1)
+
+
+# Replay command
+@client.slash_command(dm_permission=False)
+@application_checks.has_role(config.dj_role_name)
+async def replay(interaction: Interaction) -> None:
+    """Replay currently playing song from the beginning."""
+    bc = bust.controllers.get(interaction.guild_id)
+
+    if not bc or not bc.is_active():
+        await interaction.send("Nothing is playing.", ephemeral=True)
+        return
+
+    await interaction.send("Replaying this track.")
+    bc.skip_to_track(bc.playing_index)
 
 
 # Stop command

--- a/src/main.py
+++ b/src/main.py
@@ -177,7 +177,7 @@ async def stop(interaction: Interaction) -> None:
         return
 
     await interaction.send("Alright I'll shut up.")
-    await bc.stop()
+    bc.stop()
 
 
 # Image command


### PR DESCRIPTION
Add replay command, which may or may not incidentally help recover from crashes, not that we ever have those or anything.

Done by changing the for-loop for songs to a BustController-wide index which is incremented each time, and which can be manipulated when playback is cancelled. Also removed async from BustController `stop()` function since idk why it was there.

Merged code for skip and replay. Could even merge in stop if we just make stop a "skip" to track index of len(bust_content)? But idk if that's confusing. Have tested skip/replay/stop and they all work fine at both index 0 and index nonzero. Made code generic so implementing a `/skip <num>` with a number argument would be ez. We can give it to an intern.