### PR TITLE
Change mutagen dependency from git to release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord_emoji>=1.4.1
-git+https://github.com/quodlibet/mutagen.git
+mutagen>=1.47.0
 nextcord[voice]>=2.4.1
 google-api-python-client>=2.57.0
 oauth2client>=4.1.3


### PR DESCRIPTION
Closes #205. Now that mutagen has had an [official release](https://github.com/quodlibet/mutagen/releases/tag/release-1.47.0), the PR we submitted (https://github.com/quodlibet/mutagen/pull/601) to properly detect extensionless ID3-less mp3s is in the repo version, and we no longer need to depend on the git release.