### PR TITLE
Catch all exceptions when generating album art

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -346,7 +346,7 @@ async def generate_image(prompt: str) -> Optional[str]:
             quality="standard",
             n=1,
         )
-    except openai.BadRequestError:
-        print(f"Warning: Bad request for prompt {prompt}")
+    except Exception as e:
+        print("OpenAI API exception:", e)
         return None
     return response.data[0].url


### PR DESCRIPTION
the OpenAI API has a lot of [error codes](https://platform.openai.com/docs/guides/error-codes). Surrounding the part where we query the LLM, we have a blanket `catch Exception as e` block. We tried to catch the one specific exception we saw around the DALL-E call but we didnt catch another one which caused Busty to crash last bust due to OpenAI API outages.

I can sympathize with the fact that it's somewhat sketchy to catch all exceptions, but ultimately this is a non-critical feature with the potential of killing the bust if an exception slips through, and catching like 10 different Exception types explicitly all in a row seems overkill and ugly for this project.

If someone disagrees feel free to add your own error handling in a separate commit, but I think #1 priority should be guarding busty against crashing from non-critical failures at the moment.

Happy Thanksgiving