### PR TITLE
Fix unbound bot_state_str variable on first load

### DIFF
--- a/src/persistent_state.py
+++ b/src/persistent_state.py
@@ -20,7 +20,7 @@ def load_state_from_disk() -> None:
             bot_state_str = f.read()
     except FileNotFoundError:
         # Expected on first run or after setting a new custom bot state filepath.
-        pass
+        bot_state_str = None
     except IOError:
         print(f"Could not read state from {bot_state_file}")
         raise


### PR DESCRIPTION
Busty crashes due to this unbound variable on line 28 if you have no state file.