### PR TITLE
Show a configurable number of top submitters

### DIFF
--- a/src/bust.py
+++ b/src/bust.py
@@ -386,11 +386,11 @@ class BustController:
 
         # Format list of users with longest total submission length
         submitters_sorted_by_len = sorted(
-            [(len, sub) for (sub, len) in submitter_to_len.items()], reverse=True
+            [(length, sub) for (sub, length) in submitter_to_len.items()], reverse=True
         )
         longest_submitters_formatted = [
-            f"{i+1}. {submitter.mention} - {song_utils.format_time(int(len))}"
-            for i, (len, submitter) in enumerate(
+            f"{i+1}. {submitter.mention} - {song_utils.format_time(int(length))}"
+            for i, (length, submitter) in enumerate(
                 submitters_sorted_by_len[: config.num_longest_submitters]
             )
         ]

--- a/src/bust.py
+++ b/src/bust.py
@@ -384,9 +384,16 @@ class BustController:
                 song_len = 0.0
             submitter_to_len[submit_message.author] += song_len
 
-        # User with longest total submission length
-        longest_submitter = max(submitter_to_len, key=submitter_to_len.get)
-        longest_submitter_time = int(submitter_to_len[longest_submitter])
+        # Format list of users with longest total submission length
+        submitters_sorted_by_len = sorted(
+            [(len, sub) for (sub, len) in submitter_to_len.items()], reverse=True
+        )
+        longest_submitters_formatted = [
+            f"{i+1}. {submitter.mention} - {song_utils.format_time(int(len))}"
+            for i, (len, submitter) in enumerate(
+                submitters_sorted_by_len[: config.num_longest_submitters]
+            )
+        ]
 
         embed_text = "\n".join(
             [
@@ -394,9 +401,9 @@ class BustController:
                 f"*Total track length:* {song_utils.format_time(songs_len)}",
                 f"*Total bust length:* {song_utils.format_time(bust_len)}",
                 f"*Unique submitters:* {len(submitter_to_len)}",
-                f"*Longest submitter:* {longest_submitter.mention} - "
-                + f"{song_utils.format_time(longest_submitter_time)}",
+                "*Longest submitters:*",
             ]
+            + longest_submitters_formatted
         )
         if errors:
             embed_text += (

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,8 @@ seconds_between_songs = int(os.environ.get("BUSTY_COOLDOWN_SECS", 10))
 attachment_directory_filepath = os.environ.get("BUSTY_ATTACHMENT_DIR", "attachments")
 # The Discord role needed to perform bot commands
 dj_role_name = os.environ.get("BUSTY_DJ_ROLE", "bangermeister")
+# Number of longest submitters to show on /info
+num_longest_submitters = int(os.environ.get("BUSTY_NUM_LONGEST_SUBMITTERS", 3))
 # The Discord bot token to use
 discord_token = os.environ.get("BUSTY_DISCORD_TOKEN")
 # The remote folder to move Google Forms to


### PR DESCRIPTION
Closes #188. This was originally just an idea for fun, but then things got real when we were explicitly asked.
![image](https://github.com/anoadragon453/busty/assets/6956898/daa36435-6ca8-4fd2-9dbe-09859d5d4a99)


Preview image (has also been tested when # of submitters is less than # to be shown)
![image](https://github.com/anoadragon453/busty/assets/6956898/18fa8e6c-6ac0-4a21-b45d-4e54048e5657)
