### PR TITLE
Add logging module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 import asyncio
+import logging
 import os
 import random
+import sys
 from typing import Optional
 
 from nextcord import (
@@ -20,6 +22,19 @@ import discord_utils
 import llm
 import persistent_state
 import song_utils
+
+
+def setup_logging(log_level):
+    logger = logging.getLogger("nextcord")
+    logger.setLevel(log_level)
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s:%(levelname)s:%(name)s: %(message)s")
+    )
+    logger.addHandler(handler)
+
+
+setup_logging(logging.INFO)
 
 # This is necessary to query guild members
 intents = Intents.default()


### PR DESCRIPTION
Fixes #196 

Nextcord uses the logging module to log all events. Without the logging module setup, errors and such will just be swallowed. This PR uses recommended settings from https://docs.nextcord.dev/en/stable/logging.html, but to stderr instead of a file.

It's getting a little ugly doing so much setup at a global level, so I plan to do some refactoring of `main.py` in another PR. I also may switch our current print logging to the logging module. But for now I think this as important change to make so we can catch future errors.