### PR TITLE
Seek to time

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -360,15 +360,16 @@ async def on_application_command_error(
     else:
         print(error)
 
-on_list.dm_permission = True
-on_bust.dm_permission = True
-skip.dm_permission = True
-replay.dm_permission = True
-stop.dm_permission = True
-image.dm_permission = True
-info.dm_permission = True
-preview.dm_permission = True
-announce.dm_permission = True
+# NextCord 3+ requires dm_permission parameters outside of the slash_command declaration
+on_list.dm_permission = False
+on_bust.dm_permission = False
+skip.dm_permission = False
+replay.dm_permission = False
+stop.dm_permission = False
+image.dm_permission = False
+info.dm_permission = False
+preview.dm_permission = False
+announce.dm_permission = False
 
 # Load the bot state.
 persistent_state.load_state_from_disk()

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,8 @@ from nextcord import (
     Message,
     SlashOption,
     TextChannel,
+    SlashCommandOption,
+    application_command,
 )
 from nextcord.ext import application_checks, commands
 
@@ -77,7 +79,7 @@ list_task_control_lock = asyncio.Lock()
 
 
 # List command
-@client.slash_command(name="list", dm_permission=False)
+@client.slash_command(name="list")
 @application_checks.has_role(config.dj_role_name)
 async def on_list(
     interaction: Interaction,
@@ -106,7 +108,7 @@ async def on_list(
 
 
 # Bust command
-@client.slash_command(name="bust", dm_permission=False)
+@client.slash_command(name="bust")
 @application_checks.has_role(config.dj_role_name)
 async def on_bust(
     interaction: Interaction,
@@ -115,6 +117,10 @@ async def on_bust(
         min_value=1,
         default=1,
         description="Track number to start from.",
+    ),
+    starttime: str = SlashOption(
+        required=False,
+        description="Timestamp or time in seconds to seek the starting song from.",
     ),
 ) -> None:
     """Begin a bust."""
@@ -131,12 +137,12 @@ async def on_bust(
     if index > len(bc.bust_content):
         await interaction.send("There aren't that many tracks.", ephemeral=True)
         return
-    await bc.play(interaction, index - 1)
+    await bc.play(interaction, index - 1, starttime)
     del bust.controllers[interaction.guild_id]
 
 
 # Skip command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def skip(interaction: Interaction) -> None:
     """Skip currently playing song."""
@@ -151,7 +157,7 @@ async def skip(interaction: Interaction) -> None:
 
 
 # Replay command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def replay(interaction: Interaction) -> None:
     """Replay currently playing song from the beginning."""
@@ -166,7 +172,7 @@ async def replay(interaction: Interaction) -> None:
 
 
 # Stop command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def stop(interaction: Interaction) -> None:
     """Stop playback."""
@@ -181,7 +187,7 @@ async def stop(interaction: Interaction) -> None:
 
 
 # Image command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def image(interaction: Interaction) -> None:
     """Manage saved Google Forms image."""
@@ -240,7 +246,7 @@ async def image_view(interaction: Interaction) -> None:
 
 
 # Info command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def info(interaction: Interaction) -> None:
     """Get info about currently listed songs."""
@@ -254,7 +260,7 @@ async def info(interaction: Interaction) -> None:
 
 
 # Preview command
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 async def preview(
     interaction: Interaction,
     uploaded_file: Attachment = SlashOption(description="The song to submit."),
@@ -302,7 +308,7 @@ async def preview(
     os.remove(attachment_filepath)
 
 
-@client.slash_command(dm_permission=False)
+@client.slash_command()
 @application_checks.has_role(config.dj_role_name)
 async def announce(
     interaction: Interaction,
@@ -354,6 +360,15 @@ async def on_application_command_error(
     else:
         print(error)
 
+on_list.dm_permission = True
+on_bust.dm_permission = True
+skip.dm_permission = True
+replay.dm_permission = True
+stop.dm_permission = True
+image.dm_permission = True
+info.dm_permission = True
+preview.dm_permission = True
+announce.dm_permission = True
 
 # Load the bot state.
 persistent_state.load_state_from_disk()

--- a/src/song_utils.py
+++ b/src/song_utils.py
@@ -232,3 +232,40 @@ def get_cover_art(filename: str) -> Optional[File]:
 
     # Create a new discord file from the file pointer and name
     return File(image_bytes_fp, filename=cover_filename)
+
+def convert_timestamp_to_seconds(time_str):
+    # Converts a time string into seconds. Returns 0 if format is invalid.
+    # Format is handled either in pure seconds (93, 180) or hh:mm:ss format (1:23:45).
+    if time_str is None:
+        return 0
+    
+    if ':' not in time_str:
+        if not time_str.isdigit():
+            return 0
+        return int(time_str)
+    
+    # Split the time string by colons
+    parts = time_str.split(':')
+    
+    if len(parts) > 3:
+        return 0
+    
+    # All parts must be digits
+    if not all(part.isdigit() for part in parts):
+        return 0
+    parts = [int(part) for part in parts]
+
+    # Pad with zeros if needed (e.g., "1:23" becomes [0, 1, 23])
+    while len(parts) < 3:
+        parts.insert(0, 0)
+        
+    # Calculate total seconds
+    hours, minutes, seconds = parts
+    
+    # Validate ranges
+    if minutes >= 60 or seconds >= 60:
+        return 0
+    if hours < 0 or minutes < 0 or seconds < 0:
+        return 0
+        
+    return (hours * 3600) + (minutes * 60) + seconds


### PR DESCRIPTION
When busty crashes mid-song and the song is rather long, it's often ideal to try to start again in the middle.  This PR adds a parameter to the /bust command called starttime that allows users to enter a time either in seconds (93) or timestamp format (1:15), (01:23:45). Busty will convert the portion of the song into ogg format to avoid chip/pop artifacts introduced by the FFmpegPCMAudio function and play the converted song as Discord intended (because they love ogg sooooo very much), then proceed to the next song as per usual.

This was tested on a Windows machine using NextCord 3.0.1, there were breaking changes to slash_command introduced in 3.0.0 that required me to format the parameters separately in order to run. Let me know and I can revert those if needed.