### PR TITLE
Allow using a separate tokenizer model

### DIFF
--- a/src/busty/config.py
+++ b/src/busty/config.py
@@ -56,7 +56,9 @@ testing_guild = os.environ.get("BUSTY_TESTING_GUILD_ID", None)
 # OpenAI API Key
 openai_api_key = os.environ.get("BUSTY_OPENAI_API_KEY", None)
 # The OpenAI model to use for GPT abilities
-openai_model = os.environ.get("BUSTY_OPENAI_MODEL", "gpt-3.5-turbo")
+openai_model = os.environ.get("BUSTY_OPENAI_MODEL", "gpt-4.1")
+# The OpenAI model to use for tokenization (defaults to same as openai_model)
+openai_tokenizer_model = os.environ.get("BUSTY_OPENAI_TOKENIZER", openai_model)
 
 # TYPES
 # Acceptable data types to store in a JSON representation.

--- a/src/busty/llm.py
+++ b/src/busty/llm.py
@@ -39,7 +39,7 @@ def initialize(client: Client) -> None:
     openai_async_client = openai.AsyncOpenAI(api_key=config.openai_api_key)
 
     # Preload tokenizer
-    encoding = tiktoken.encoding_for_model(config.openai_model)
+    encoding = tiktoken.encoding_for_model(config.openai_tokenizer_model)
     # Store bot user
     self_user = client.user
     # Cache regex for banned words


### PR DESCRIPTION
For a long time busty has been stuck on GPT-4o because we naively assumed OpenAI would keep the mapping from models to tokenizers in their `tiktoken` library up to date. This doesn't seem to be the case, so we need to manually specify a tokenizer separately from the model in order to use newer models. This just adds a separate optional settings to do so. Actually the default setup of using the gpt-4.1 for the tokenizer is broken, it needs to be manually specified as gpt-4o. But it feels almost wrong baking in the jankness to our default config, since it's all expected to be overridden anyways.

I promise I'll get around to fixing the typechecking... soon...