### PR TITLE
Refactor ChatService code and format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ format: ## Format the code with ruff
 	ruff format .
 
 type-check: ## Type check the code with mypy
-	mypy src/
+	uv run mypy src/
 
 test: ## Run tests with pytest
 	uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "types-requests>=2.31.0",
     "types-Pillow>=10.0.0",
     "colorlog>=6.8.0",
+    "pyyaml>=6.0.0",
+    "types-PyYAML>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/busty/ai/chat_service.py
+++ b/src/busty/ai/chat_service.py
@@ -151,7 +151,10 @@ CHAT_TOOLS = [
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "content": {"type": "string", "description": "what you want to say"},
+                    "content": {
+                        "type": "string",
+                        "description": "what you want to say",
+                    },
                     "emojis": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -352,7 +355,9 @@ class ChatService:
         # Build messages array
         messages = [system_msg] + list(reversed(history))
 
-        logger.debug(f"Calling LLM with {len(messages)} total messages (1 system + {len(history)} history)")
+        logger.debug(
+            f"Calling LLM with {len(messages)} total messages (1 system + {len(history)} history)"
+        )
         logger.debug(f"Temperature: {constants.CHAT_TEMPERATURE}")
         tool_names = [tool["function"]["name"] for tool in CHAT_TOOLS]  # type: ignore
         logger.debug(f"Tools available: {tool_names}")

--- a/src/busty/ai/openai_service.py
+++ b/src/busty/ai/openai_service.py
@@ -29,13 +29,17 @@ class OpenAIService:
         return self._client is not None
 
     async def complete_chat(
-        self, messages: list[dict[str, str]], max_tokens: int = 512
+        self,
+        messages: list[dict[str, str]],
+        max_tokens: int = 512,
+        temperature: float = 1.0,
     ) -> str | None:
         """Send messages to OpenAI and return completion text.
 
         Args:
             messages: List of {"role": ..., "content": ...} dicts.
             max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature (0.0-2.0). Higher = more random/creative.
 
         Returns:
             Response text, or None if AI unavailable or error occurs.
@@ -47,6 +51,7 @@ class OpenAIService:
             response = await self._client.chat.completions.create(
                 model=self.settings.openai_model,
                 messages=messages,  # type: ignore
+                temperature=temperature,
                 timeout=constants.LLM_RESPONSE_TIMEOUT,
             )
             return response.choices[0].message.content
@@ -55,13 +60,17 @@ class OpenAIService:
             return None
 
     async def complete_chat_with_tools(
-        self, messages: list[dict[str, str]], tools: list[dict]
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float = 1.0,
     ) -> dict:
         """Send messages to OpenAI with tool/function calling.
 
         Args:
             messages: List of {"role": ..., "content": ...} dicts.
             tools: List of tool definitions for function calling.
+            temperature: Sampling temperature (0.0-2.0). Higher = more random/creative.
 
         Returns:
             Response dict with 'content' and 'tool_calls' keys.
@@ -77,6 +86,7 @@ class OpenAIService:
             messages=messages,  # type: ignore
             tools=tools,  # type: ignore
             tool_choice="required",  # Force the model to call a function
+            temperature=temperature,
             timeout=constants.LLM_RESPONSE_TIMEOUT,
         )
 

--- a/src/busty/ai/protocols.py
+++ b/src/busty/ai/protocols.py
@@ -1,6 +1,6 @@
 """Protocol definitions for AI services."""
 
-from typing import Protocol
+from typing import Any, Protocol
 
 from busty.track import Track
 
@@ -31,6 +31,21 @@ class AIService(Protocol):
 
         Returns:
             Response text, or None if AI unavailable or error occurs.
+        """
+        ...
+
+    async def complete_chat_with_tools(
+        self, messages: list[dict[str, str]], tools: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Send messages to AI with tool/function calling.
+
+        Args:
+            messages: List of {"role": ..., "content": ...} dicts.
+            tools: List of tool definitions for function calling.
+
+        Returns:
+            Response dict with 'content' and 'tool_calls' keys.
+            Raises exception if error occurs.
         """
         ...
 

--- a/src/busty/ai/protocols.py
+++ b/src/busty/ai/protocols.py
@@ -21,13 +21,17 @@ class AIService(Protocol):
         ...
 
     async def complete_chat(
-        self, messages: list[dict[str, str]], max_tokens: int = 512
+        self,
+        messages: list[dict[str, str]],
+        max_tokens: int = 512,
+        temperature: float = 1.0,
     ) -> str | None:
         """Send messages to AI and return completion text.
 
         Args:
             messages: List of {"role": ..., "content": ...} dicts.
             max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature (0.0-2.0). Higher = more random/creative.
 
         Returns:
             Response text, or None if AI unavailable or error occurs.
@@ -35,13 +39,17 @@ class AIService(Protocol):
         ...
 
     async def complete_chat_with_tools(
-        self, messages: list[dict[str, str]], tools: list[dict[str, Any]]
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict[str, Any]],
+        temperature: float = 1.0,
     ) -> dict[str, Any]:
         """Send messages to AI with tool/function calling.
 
         Args:
             messages: List of {"role": ..., "content": ...} dicts.
             tools: List of tool definitions for function calling.
+            temperature: Sampling temperature (0.0-2.0). Higher = more random/creative.
 
         Returns:
             Response dict with 'content' and 'tool_calls' keys.

--- a/src/busty/config/constants.py
+++ b/src/busty/config/constants.py
@@ -29,6 +29,11 @@ COVER_ART_FETCH_TIMEOUT: Final = 10.0  # seconds
 COVER_ART_GENERATE_TIMEOUT: Final = 20.0  # seconds
 LLM_RESPONSE_TIMEOUT: Final = 10.0  # seconds
 
+# Chat service constants
+CHAT_BUSY_EMOJI: Final = "\N{RAISED HAND}"  # No skin tone modifier for neutrality
+CHAT_MESSAGE_TOO_LONG_REPLY: Final = "I'm not reading all that."
+CHAT_ERROR_REPLY: Final = "busy rn"
+
 # User preference defaults
 AI_ART_ENABLED_DEFAULT: Final = True  # opt-out system
 MAILBOX_PREVIEW_ENABLED_DEFAULT: Final = True  # opt-out system

--- a/src/busty/config/constants.py
+++ b/src/busty/config/constants.py
@@ -33,6 +33,7 @@ LLM_RESPONSE_TIMEOUT: Final = 10.0  # seconds
 CHAT_BUSY_EMOJI: Final = "\N{RAISED HAND}"  # No skin tone modifier for neutrality
 CHAT_MESSAGE_TOO_LONG_REPLY: Final = "I'm not reading all that."
 CHAT_ERROR_REPLY: Final = "busy rn"
+CHAT_TEMPERATURE: Final = 1.2  # Higher temperature for varied, human-like responses
 
 # User preference defaults
 AI_ART_ENABLED_DEFAULT: Final = True  # opt-out system

--- a/src/busty/config/settings.py
+++ b/src/busty/config/settings.py
@@ -79,7 +79,7 @@ class BustySettings:
 
         # Compute file paths (hardcoded structure)
         bot_state_file = state_dir / "bot_state.json"
-        llm_context_file = config_dir / "llm_context.json"
+        llm_context_file = config_dir / "llm_context.yaml"
         google_auth_file = auth_dir / "oauth_token.json"
 
         # Load OpenAI model (used for both model and tokenizer by default)

--- a/src/busty/config/settings.py
+++ b/src/busty/config/settings.py
@@ -52,6 +52,9 @@ class BustySettings:
     # Mailbox channel detection
     mailbox_channel_prefix: str
 
+    # Logging
+    log_level: int
+
     @staticmethod
     def from_environment() -> "BustySettings":
         """Load settings from environment variables.
@@ -85,6 +88,10 @@ class BustySettings:
         # Load OpenAI model (used for both model and tokenizer by default)
         openai_model = os.environ.get("BUSTY_OPENAI_MODEL", "gpt-4o")
 
+        # Load log level
+        log_level_name = os.environ.get("BUSTY_LOG_LEVEL", "INFO").upper()
+        log_level = getattr(logging, log_level_name, logging.INFO)
+
         return BustySettings(
             discord_token=os.environ.get("BUSTY_DISCORD_TOKEN"),
             dj_role_name=os.environ.get("BUSTY_DJ_ROLE", "bangermeister"),
@@ -113,6 +120,7 @@ class BustySettings:
             mailbox_channel_prefix=os.environ.get(
                 "BUSTY_MAILBOX_PREFIX", "bustys-mailbox-"
             ),
+            log_level=log_level,
         )
 
     def validate(self, logger: logging.Logger) -> None:

--- a/src/busty/main.py
+++ b/src/busty/main.py
@@ -39,12 +39,14 @@ def setup_logging(log_level: int) -> None:
 
 def run_bot() -> None:
     """Entry point for the busty script."""
-    # Setup logging
-    setup_logging(logging.INFO)
+    # Load settings first
+    settings = BustySettings.from_environment()
+
+    # Setup logging with configured level
+    setup_logging(settings.log_level)
     logger.info("Starting Busty bot")
 
-    # Load settings
-    settings = BustySettings.from_environment()
+    # Validate settings (uses logger, so must come after setup_logging)
     settings.validate(logger)
 
     if settings.testing_guild:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures and utilities."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,7 @@ def settings() -> BustySettings:
         num_longest_submitters=3,
         emoji_list=["🎵", "🎶", "🎸"],  # Sample emojis for tests
         mailbox_channel_prefix="bustys-mailbox-",  # Default for tests
+        log_level=logging.INFO,  # Default log level for tests
     )
 
 


### PR DESCRIPTION
Large refactor and reformat of the way the ChatService works. It's not much more type safe, and adheres to best practices for agentic coding.
- Markdown-based sysprompt
- LLM context file changed from json to more human-friendly yaml
- Respond to messages through tool calls
- React to messages through tool calls
- Ability to ignore messages entirely

Some care still needs to be taken to ensure that busty is still fun to talk to. This I think can only really be done live